### PR TITLE
Implement `Arrayable` and `JsonSerializable` along with `Message` adjustments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -388,9 +388,11 @@ The `Message` class provides several methods to access basic properties:
 
 **Headers and Contents**
 
-- `$message->headers()`: Returns the raw headers as a string.
-- `$message->contents()`: Returns the raw message content.
-- `$message->hasHeaders()` / `hasContents()`: Determine whether the message has headers or contents.
+- `$message->head()`: Returns the raw message header.
+- `$message->body()`: Returns the raw message body.
+- `$message->header($name)`: Returns a specific header.
+- `$message->headers()`: Returns an array of all headers.
+- `$message->hasHead()` / `hasBody()`: Determine whether the message has headers or body.
 
 **Metadata**
 

--- a/src/Address.php
+++ b/src/Address.php
@@ -2,7 +2,10 @@
 
 namespace DirectoryTree\ImapEngine;
 
-class Address
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+class Address implements Arrayable, JsonSerializable
 {
     /**
      * Constructor.
@@ -26,5 +29,24 @@ class Address
     public function name(): string
     {
         return $this->name;
+    }
+
+    /**
+     * Get the array representation of the address.
+     */
+    public function toArray(): array
+    {
+        return [
+            'email' => $this->email,
+            'name' => $this->name,
+        ];
+    }
+
+    /**
+     * Get the JSON representation of the address.
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 }

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -2,10 +2,12 @@
 
 namespace DirectoryTree\ImapEngine;
 
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Mime\MimeTypes;
 
-class Attachment
+class Attachment implements Arrayable, JsonSerializable
 {
     /**
      * Constructor.
@@ -70,5 +72,25 @@ class Attachment
         }
 
         return null;
+    }
+
+    /**
+     * Get the array representation of the attachment.
+     */
+    public function toArray(): array
+    {
+        return [
+            'filename' => $this->filename,
+            'contentType' => $this->contentType,
+            'contents' => $this->contents(),
+        ];
+    }
+
+    /**
+     * Get the JSON representation of the attachment.
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 }

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -81,7 +81,7 @@ class Attachment implements Arrayable, JsonSerializable
     {
         return [
             'filename' => $this->filename,
-            'contentType' => $this->contentType,
+            'content_type' => $this->contentType,
             'contents' => $this->contents(),
         ];
     }

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -7,8 +7,10 @@ use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Exceptions\Exception;
 use DirectoryTree\ImapEngine\Exceptions\ImapCapabilityException;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
 
-class Folder
+class Folder implements Arrayable, JsonSerializable
 {
     /**
      * The folder's cached capabilities.
@@ -205,5 +207,25 @@ class Folder
     protected function capabilities(): array
     {
         return $this->capabilities ??= $this->mailbox->capabilities();
+    }
+
+    /**
+     * Get the array representation of the folder.
+     */
+    public function toArray(): array
+    {
+        return [
+            'path' => $this->path,
+            'flags' => $this->flags,
+            'delimiter' => $this->delimiter,
+        ];
+    }
+
+    /**
+     * Get the JSON representation of the folder.
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -30,8 +30,8 @@ class Message implements Arrayable, JsonSerializable, Stringable
         protected Folder $folder,
         protected int $uid,
         protected array $flags,
-        protected string $headers,
-        protected string $contents,
+        protected string $head,
+        protected string $body,
     ) {}
 
     /**
@@ -62,33 +62,33 @@ class Message implements Arrayable, JsonSerializable, Stringable
     /**
      * Get the message's raw headers.
      */
-    public function headers(): string
+    public function head(): string
     {
-        return $this->headers;
+        return $this->head;
     }
 
     /**
      * Determine if the message has headers.
      */
-    public function hasHeaders(): bool
+    public function hasHead(): bool
     {
-        return ! empty($this->headers);
+        return ! empty($this->head);
     }
 
     /**
-     * Get the message's raw contents.
+     * Get the message's raw body.
      */
-    public function contents(): string
+    public function body(): string
     {
-        return $this->contents;
+        return $this->body;
     }
 
     /**
      * Determine if the message has contents.
      */
-    public function hasContents(): bool
+    public function hasBody(): bool
     {
-        return ! empty($this->contents);
+        return ! empty($this->body);
     }
 
     /**
@@ -298,6 +298,14 @@ class Message implements Arrayable, JsonSerializable, Stringable
     }
 
     /**
+     * Get all headers from the message.
+     */
+    public function headers(): array
+    {
+        return $this->parse()->getAllHeaders();
+    }
+
+    /**
      * Get a header from the message.
      */
     public function header(string $name, int $offset = 0): ?IHeader
@@ -483,7 +491,7 @@ class Message implements Arrayable, JsonSerializable, Stringable
      */
     public function parse(): MailMimeMessage
     {
-        if (! $this->hasHeaders() && ! $this->hasContents()) {
+        if (! $this->hasHead() && ! $this->hasBody()) {
             throw new RuntimeException('Cannot parse an empty message');
         }
 
@@ -498,8 +506,8 @@ class Message implements Arrayable, JsonSerializable, Stringable
         return [
             'uid' => $this->uid,
             'flags' => $this->flags,
-            'headers' => $this->headers,
-            'contents' => $this->contents,
+            'head' => $this->head,
+            'body' => $this->body,
         ];
     }
 
@@ -509,8 +517,8 @@ class Message implements Arrayable, JsonSerializable, Stringable
     public function __toString(): string
     {
         return implode("\r\n\r\n", array_filter([
-            rtrim($this->headers),
-            ltrim($this->contents),
+            rtrim($this->head),
+            ltrim($this->body),
         ]));
     }
 

--- a/src/Pagination/LengthAwarePaginator.php
+++ b/src/Pagination/LengthAwarePaginator.php
@@ -129,7 +129,7 @@ class LengthAwarePaginator implements Arrayable, JsonSerializable
     }
 
     /**
-     * Convert the pagination data to an array.
+     * Get the array representation of the paginator.
      */
     public function toArray(): array
     {
@@ -164,7 +164,7 @@ class LengthAwarePaginator implements Arrayable, JsonSerializable
     }
 
     /**
-     * Convert the instance to JSON.
+     * Get the JSON representation of the paginator.
      */
     public function jsonSerialize(): array
     {


### PR DESCRIPTION
Going to make an exception this once for breaking change here for adding the ability to retrieve headers properly on messages. These methods should have been named better before release 😞 