### PR TITLE
Bug 20 - IDLE fails with Invalid message number when message moved/deleted after receiving

### DIFF
--- a/src/Connection/ImapCommand.php
+++ b/src/Connection/ImapCommand.php
@@ -23,6 +23,30 @@ class ImapCommand implements Stringable
     ) {}
 
     /**
+     * Get the IMAP tag.
+     */
+    public function tag(): string
+    {
+        return $this->tag;
+    }
+
+    /**
+     * Get the IMAP command.
+     */
+    public function command(): string
+    {
+        return $this->command;
+    }
+
+    /**
+     * Get the IMAP tokens.
+     */
+    public function tokens(): array
+    {
+        return $this->tokens;
+    }
+
+    /**
      * Compile the command into lines for transmission.
      *
      * @return string[]
@@ -62,7 +86,7 @@ class ImapCommand implements Stringable
      */
     public function redacted(): ImapCommand
     {
-        return new ImapCommand($this->tag, $this->command, array_map(
+        return new static($this->tag, $this->command, array_map(
             function (mixed $token) {
                 return is_array($token)
                     ? array_map(fn () => '[redacted]', $token)

--- a/src/Exceptions/ImapCommandException.php
+++ b/src/Exceptions/ImapCommandException.php
@@ -8,10 +8,41 @@ use DirectoryTree\ImapEngine\Connection\Responses\Response;
 class ImapCommandException extends Exception
 {
     /**
+     * The IMAP response.
+     */
+    protected Response $response;
+
+    /**
+     * The failed IMAP command.
+     */
+    protected ImapCommand $command;
+
+    /**
      * Make a new instance from a failed command and response.
      */
     public static function make(ImapCommand $command, Response $response): static
     {
-        return new static(sprintf('IMAP command "%s" failed. Response: "%s"', $command, $response));
+        $exception = new static(sprintf('IMAP command "%s" failed. Response: "%s"', $command, $response));
+
+        $exception->command = $command;
+        $exception->response = $response;
+
+        return $exception;
+    }
+
+    /**
+     * Get the failed IMAP command.
+     */
+    public function command(): ImapCommand
+    {
+        return $this->command;
+    }
+
+    /**
+     * Get the IMAP response.
+     */
+    public function response(): Response
+    {
+        return $this->response;
     }
 }

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -8,6 +8,7 @@ use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Exceptions\Exception;
 use DirectoryTree\ImapEngine\Exceptions\ImapCapabilityException;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\ItemNotFoundException;
 use JsonSerializable;
 
 class Folder implements Arrayable, JsonSerializable
@@ -115,8 +116,12 @@ class Folder implements Arrayable, JsonSerializable
 
                 try {
                     $message = $fetch($msgn);
+                } catch (ItemNotFoundException) {
+                    // The message wasn't found. We will skip
+                    // it and continue awaiting new messages.
+                    return;
                 } catch (Exception) {
-                    // If fetching the message fails, we'll attempt
+                    // Something else happened. We will attempt
                     // reconnecting and re-fetching the message.
                     $this->mailbox->reconnect();
 


### PR DESCRIPTION
Closes #20 

This appears to only occur in some IMAP providers (such as Dovecot). I'm unable to reproduce this using Greenmail in integration tests.