### PR TITLE
Add `FileMessage` for reading `.eml` files

### DIFF
--- a/src/FileMessage.php
+++ b/src/FileMessage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DirectoryTree\ImapEngine;
+
+use Stringable;
+
+class FileMessage implements Stringable
+{
+    use HasParsedMessage;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        protected string $contents
+    ) {}
+
+    /**
+     * Get the string representation of the message.
+     */
+    public function __toString(): string
+    {
+        return $this->contents;
+    }
+
+    /**
+     * Determine if the message is empty.
+     */
+    protected function isEmpty(): bool
+    {
+        return empty($this->contents);
+    }
+}

--- a/src/HasParsedMessage.php
+++ b/src/HasParsedMessage.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace DirectoryTree\ImapEngine;
+
+use Carbon\Carbon;
+use DirectoryTree\ImapEngine\Exceptions\RuntimeException;
+use ZBateson\MailMimeParser\Header\HeaderConsts;
+use ZBateson\MailMimeParser\Header\IHeader;
+use ZBateson\MailMimeParser\Header\IHeaderPart;
+use ZBateson\MailMimeParser\Header\Part\AddressPart;
+use ZBateson\MailMimeParser\Header\Part\ContainerPart;
+use ZBateson\MailMimeParser\Header\Part\NameValuePart;
+use ZBateson\MailMimeParser\Message as MailMimeMessage;
+use ZBateson\MailMimeParser\Message\MimePart;
+
+trait HasParsedMessage
+{
+    /**
+     * The parsed message.
+     */
+    protected ?MailMimeMessage $parsed = null;
+
+    /**
+     * Get the message date and time.
+     */
+    public function date(): ?Carbon
+    {
+        if ($date = $this->header(HeaderConsts::DATE)?->getDateTime()) {
+            return Carbon::instance($date);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the message's message-id.
+     */
+    public function messageId(): ?string
+    {
+        return $this->header(HeaderConsts::MESSAGE_ID)?->getValue();
+    }
+
+    /**
+     * Get the message's subject.
+     */
+    public function subject(): ?string
+    {
+        return $this->header(HeaderConsts::SUBJECT)?->getValue();
+    }
+
+    /**
+     * Get the FROM address.
+     */
+    public function from(): ?Address
+    {
+        return head($this->addresses(HeaderConsts::FROM)) ?: null;
+    }
+
+    /**
+     * Get the SENDER address.
+     */
+    public function sender(): ?Address
+    {
+        return head($this->addresses(HeaderConsts::SENDER)) ?: null;
+    }
+
+    /**
+     * Get the REPLY-TO address.
+     */
+    public function replyTo(): ?Address
+    {
+        return head($this->addresses(HeaderConsts::REPLY_TO)) ?: null;
+    }
+
+    /**
+     * Get the IN-REPLY-TO address.
+     */
+    public function inReplyTo(): ?Address
+    {
+        return head($this->addresses(HeaderConsts::IN_REPLY_TO)) ?: null;
+    }
+
+    /**
+     * Get the TO addresses.
+     *
+     * @return Address[]
+     */
+    public function to(): array
+    {
+        return $this->addresses(HeaderConsts::TO);
+    }
+
+    /**
+     * Get the CC addresses.
+     *
+     * @return Address[]
+     */
+    public function cc(): array
+    {
+        return $this->addresses(HeaderConsts::CC);
+    }
+
+    /**
+     * Get the BCC addresses.
+     *
+     * @return Address[]
+     */
+    public function bcc(): array
+    {
+        return $this->addresses(HeaderConsts::BCC);
+    }
+
+    /**
+     * Get the message's attachments.
+     *
+     * @return Attachment[]
+     */
+    public function attachments(): array
+    {
+        return array_map(function (MimePart $part) {
+            return new Attachment(
+                $part->getFilename(),
+                $part->getContentType(),
+                $part->getContentStream(),
+            );
+        }, $this->parse()->getAllAttachmentParts());
+    }
+
+    /**
+     * Determine if the message has attachments.
+     */
+    public function hasAttachments(): bool
+    {
+        return $this->attachmentCount() > 0;
+    }
+
+    /**
+     * Get the count of attachments.
+     */
+    public function attachmentCount(): int
+    {
+        return $this->parse()->getAttachmentCount();
+    }
+
+    /**
+     * Get addresses from the given header.
+     *
+     * @return Address[]
+     */
+    public function addresses(string $header): array
+    {
+        $parts = $this->header($header)?->getParts() ?? [];
+
+        $addresses = array_map(fn (IHeaderPart $part) => match (true) {
+            $part instanceof AddressPart => new Address($part->getEmail(), $part->getName()),
+            $part instanceof NameValuePart => new Address($part->getName(), $part->getValue()),
+            $part instanceof ContainerPart => new Address($part->getValue(), ''),
+            default => null,
+        }, $parts);
+
+        return array_filter($addresses);
+    }
+
+    /**
+     * Get the message's HTML content.
+     */
+    public function html(): ?string
+    {
+        return $this->parse()->getHtmlContent();
+    }
+
+    /**
+     * Get the message's text content.
+     */
+    public function text(): ?string
+    {
+        return $this->parse()->getTextContent();
+    }
+
+    /**
+     * Get all headers from the message.
+     */
+    public function headers(): array
+    {
+        return $this->parse()->getAllHeaders();
+    }
+
+    /**
+     * Get a header from the message.
+     */
+    public function header(string $name, int $offset = 0): ?IHeader
+    {
+        return $this->parse()->getHeader($name, $offset);
+    }
+
+    /**
+     * Parse the message into a MailMimeMessage instance.
+     */
+    public function parse(): MailMimeMessage
+    {
+        if ($this->isEmpty()) {
+            throw new RuntimeException('Cannot parse an empty message');
+        }
+
+        return $this->parsed ??= MessageParser::parse((string) $this);
+    }
+
+    /**
+     * Determine if the message is empty.
+     */
+    abstract protected function isEmpty(): bool;
+
+    /**
+     * Get the string representation of the message.
+     */
+    abstract public function __toString(): string;
+}

--- a/src/Message.php
+++ b/src/Message.php
@@ -3,25 +3,15 @@
 namespace DirectoryTree\ImapEngine;
 
 use BackedEnum;
-use Carbon\Carbon;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
-use DirectoryTree\ImapEngine\Exceptions\RuntimeException;
 use DirectoryTree\ImapEngine\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use Stringable;
-use ZBateson\MailMimeParser\Header\HeaderConsts;
-use ZBateson\MailMimeParser\Header\IHeader;
-use ZBateson\MailMimeParser\Header\Part\AddressPart;
-use ZBateson\MailMimeParser\Message as MailMimeMessage;
-use ZBateson\MailMimeParser\Message\MimePart;
 
 class Message implements Arrayable, JsonSerializable, Stringable
 {
-    /**
-     * The parsed message.
-     */
-    protected ?MailMimeMessage $parsed = null;
+    use HasParsedMessage;
 
     /**
      * Constructor.
@@ -92,156 +82,6 @@ class Message implements Arrayable, JsonSerializable, Stringable
     }
 
     /**
-     * Get the message date and time.
-     */
-    public function date(): ?Carbon
-    {
-        if ($date = $this->header(HeaderConsts::DATE)?->getDateTime()) {
-            return Carbon::instance($date);
-        }
-
-        return null;
-    }
-
-    /**
-     * Get the message's message-id.
-     */
-    public function messageId(): ?string
-    {
-        return $this->header(HeaderConsts::MESSAGE_ID)?->getValue();
-    }
-
-    /**
-     * Get the message's subject.
-     */
-    public function subject(): ?string
-    {
-        return $this->header(HeaderConsts::SUBJECT)?->getValue();
-    }
-
-    /**
-     * Get the FROM address.
-     */
-    public function from(): ?Address
-    {
-        return head($this->addresses(HeaderConsts::FROM)) ?: null;
-    }
-
-    /**
-     * Get the SENDER address.
-     */
-    public function sender(): ?Address
-    {
-        return head($this->addresses(HeaderConsts::SENDER)) ?: null;
-    }
-
-    /**
-     * Get the REPLY-TO address.
-     */
-    public function replyTo(): ?Address
-    {
-        return head($this->addresses(HeaderConsts::REPLY_TO)) ?: null;
-    }
-
-    /**
-     * Get the IN-REPLY-TO address.
-     */
-    public function inReplyTo(): ?Address
-    {
-        return head($this->addresses(HeaderConsts::IN_REPLY_TO)) ?: null;
-    }
-
-    /**
-     * Get the TO addresses.
-     *
-     * @return Address[]
-     */
-    public function to(): array
-    {
-        return $this->addresses(HeaderConsts::TO);
-    }
-
-    /**
-     * Get the CC addresses.
-     *
-     * @return Address[]
-     */
-    public function cc(): array
-    {
-        return $this->addresses(HeaderConsts::CC);
-    }
-
-    /**
-     * Get the BCC addresses.
-     *
-     * @return Address[]
-     */
-    public function bcc(): array
-    {
-        return $this->addresses(HeaderConsts::BCC);
-    }
-
-    /**
-     * Get the message's attachments.
-     *
-     * @return Attachment[]
-     */
-    public function attachments(): array
-    {
-        return array_map(function (MimePart $part) {
-            return new Attachment(
-                $part->getFilename(),
-                $part->getContentType(),
-                $part->getContentStream(),
-            );
-        }, $this->parse()->getAllAttachmentParts());
-    }
-
-    /**
-     * Determine if the message has attachments.
-     */
-    public function hasAttachments(): bool
-    {
-        return $this->attachmentCount() > 0;
-    }
-
-    /**
-     * Get the count of attachments.
-     */
-    public function attachmentCount(): int
-    {
-        return $this->parse()->getAttachmentCount();
-    }
-
-    /**
-     * Get addresses from the given header.
-     *
-     * @return Address[]
-     */
-    public function addresses(string $header): array
-    {
-        return array_map(function (AddressPart $part) {
-            return new Address($part->getEmail(), $part->getName());
-        }, $this->header($header)?->getParts() ?? []);
-    }
-
-    /**
-     * Get the message's HTML content.
-     */
-    public function html(): ?string
-    {
-        return $this->parse()->getHtmlContent();
-    }
-
-    /**
-     * Get the message's text content.
-     */
-    public function text(): ?string
-    {
-        return $this->parse()->getTextContent();
-    }
-
-    /**
      * Determine if the message is marked as seen.
      */
     public function isSeen(): bool
@@ -295,22 +135,6 @@ class Message implements Arrayable, JsonSerializable, Stringable
     public function hasFlag(BackedEnum|string $flag): bool
     {
         return in_array(Str::enum($flag), $this->flags);
-    }
-
-    /**
-     * Get all headers from the message.
-     */
-    public function headers(): array
-    {
-        return $this->parse()->getAllHeaders();
-    }
-
-    /**
-     * Get a header from the message.
-     */
-    public function header(string $name, int $offset = 0): ?IHeader
-    {
-        return $this->parse()->getHeader($name, $offset);
     }
 
     /**
@@ -487,18 +311,6 @@ class Message implements Arrayable, JsonSerializable, Stringable
     }
 
     /**
-     * Parse the message into a MailMimeMessage instance.
-     */
-    public function parse(): MailMimeMessage
-    {
-        if (! $this->hasHead() && ! $this->hasBody()) {
-            throw new RuntimeException('Cannot parse an empty message');
-        }
-
-        return $this->parsed ??= MessageParser::parse((string) $this);
-    }
-
-    /**
      * Get the array representation of the message.
      */
     public function toArray(): array
@@ -528,5 +340,13 @@ class Message implements Arrayable, JsonSerializable, Stringable
     public function jsonSerialize(): array
     {
         return $this->toArray();
+    }
+
+    /**
+     * Determine if the message is empty.
+     */
+    protected function isEmpty(): bool
+    {
+        return ! $this->hasHead() && ! $this->hasBody();
     }
 }

--- a/tests/Unit/FileMessageTest.php
+++ b/tests/Unit/FileMessageTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use DirectoryTree\ImapEngine\Attachment;
+use DirectoryTree\ImapEngine\Exceptions\RuntimeException;
+use DirectoryTree\ImapEngine\FileMessage;
+
+test('it throws an exception if the message is empty', function () {
+    $message = new FileMessage('');
+
+    $message->parse(); // Attempting to parse
+})->throws(RuntimeException::class);
+
+test('it can parse a standard EML message and read basic headers', function () {
+    $contents = <<<'EOT'
+From: "John Doe" <john@example.com>
+To: "Jane Roe" <jane@example.com>
+Subject: Test Subject
+Date: Wed, 19 Feb 2025 12:34:56 -0500
+Message-ID: <unique-message-id@server.example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+
+Hello World
+EOT;
+
+    $message = new FileMessage($contents);
+
+    expect($message->subject())->toBe('Test Subject');
+    expect($message->messageId())->toBe('unique-message-id@server.example.com');
+    expect($message->date()->toDateTimeString())->toBe('2025-02-19 12:34:56');
+    expect($message->from()->email())->toBe('john@example.com');
+
+    expect($message->from()->name())->toBe('John Doe');
+    expect($message->to())->toHaveCount(1);
+    expect($message->to()[0]->email())->toBe('jane@example.com');
+    expect($message->to()[0]->name())->toBe('Jane Roe');
+    expect($message->text())->toBe('Hello World');
+});
+
+test('it can parse HTML content in a multipart message', function () {
+    $contents = <<<'EOT'
+From: "John Doe" <john@example.com>
+To: "Jane Roe" <jane@example.com>
+Subject: HTML Email
+Date: Wed, 19 Feb 2025 12:34:56 -0500
+Message-ID: <html-message@server.example.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary="----BOUNDARY-ID----"
+
+------BOUNDARY-ID----
+Content-Type: text/plain; charset="UTF-8"
+
+Hello Plain
+
+------BOUNDARY-ID----
+Content-Type: text/html; charset="UTF-8"
+
+<html><body><p>Hello <strong>HTML</strong></p></body></html>
+------BOUNDARY-ID------
+EOT;
+
+    $message = new FileMessage($contents);
+
+    expect($message->text())->toBe("Hello Plain\n");
+    expect($message->html())->toBe('<html><body><p>Hello <strong>HTML</strong></p></body></html>');
+});
+
+test('it can parse attachments', function () {
+    // Simple example with one attachment
+    $contents = <<<'EOT'
+From: "John Doe" <john@example.com>
+To: "Jane Roe" <jane@example.com>
+Subject: EML with Attachment
+Date: Wed, 19 Feb 2025 12:34:56 -0500
+Message-ID: <attachment-message@server.example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="----BOUNDARY-ID----"
+
+------BOUNDARY-ID----
+Content-Type: text/plain; charset="UTF-8"
+
+Hello with Attachment
+
+------BOUNDARY-ID----
+Content-Type: application/pdf; name="file.pdf"
+Content-Disposition: attachment; filename="file.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi0xLjUKJeLjz9MKMyAwIG9iago8PC9MZW5ndGggNCAgIC9GaWx0ZXIvQXNjaWlIYXgg
+ICAgPj5zdHJlYW0Kc3R1ZmYKZW5kc3RyZWFtCmVuZG9iajAK
+------BOUNDARY-ID------
+EOT;
+
+    $message = new FileMessage($contents);
+
+    expect($message->hasAttachments())->toBeTrue();
+    expect($message->attachmentCount())->toBe(1);
+
+    $attachments = $message->attachments();
+    expect($attachments)->toHaveCount(1);
+
+    $attachment = $attachments[0];
+    expect($attachment)->toBeInstanceOf(Attachment::class);
+    expect($attachment->filename())->toBe('file.pdf');
+    expect($attachment->contentType())->toBe('application/pdf');
+});
+
+test('it recognizes when there are no attachments', function () {
+    $contents = <<<'EOT'
+From: "John Doe" <john@example.com>
+To: "Jane Roe" <jane@example.com>
+Subject: No Attachments
+Date: Wed, 19 Feb 2025 12:34:56 -0500
+Content-Type: text/plain; charset="UTF-8"
+
+Just a plain text email without attachments.
+EOT;
+
+    $message = new FileMessage($contents);
+
+    expect($message->hasAttachments())->toBeFalse();
+    expect($message->attachmentCount())->toBe(0);
+    expect($message->attachments())->toBe([]);
+});
+
+test('it can parse other header fields like IN-REPLY-TO', function () {
+    $contents = <<<'EOT'
+From: "John Doe" <john@example.com>
+In-Reply-To: <some-other-message@server.example.com>, <another-message@server.example.com>
+Subject: In-Reply-To Check
+Date: Wed, 19 Feb 2025 12:34:56 -0500
+Content-Type: text/plain; charset="UTF-8"
+
+Check the in-reply-to header
+EOT;
+
+    $message = new FileMessage($contents);
+
+    $address = $message->inReplyTo();
+    expect($address)->not->toBeNull();
+    expect($address->email())->toBe('some-other-message@server.example.com');
+});
+
+test('it can be cast to a string via __toString()', function () {
+    $contents = <<<'EOT'
+From: "John Doe" <john@example.com>
+Subject: Stringable Test
+Date: Wed, 19 Feb 2025 12:34:56 -0500
+Content-Type: text/plain; charset="UTF-8"
+
+Testing __toString
+EOT;
+
+    $message = new FileMessage($contents);
+
+    // Casting to string should return the original contents
+    expect((string) $message)->toBe($contents);
+});

--- a/tests/Unit/FileMessageTest.php
+++ b/tests/Unit/FileMessageTest.php
@@ -7,7 +7,7 @@ use DirectoryTree\ImapEngine\FileMessage;
 test('it throws an exception if the message is empty', function () {
     $message = new FileMessage('');
 
-    $message->parse(); // Attempting to parse
+    $message->parse();
 })->throws(RuntimeException::class);
 
 test('it can parse a standard EML message and read basic headers', function () {
@@ -155,6 +155,5 @@ EOT;
 
     $message = new FileMessage($contents);
 
-    // Casting to string should return the original contents
     expect((string) $message)->toBe($contents);
 });


### PR DESCRIPTION
This PR adds a new `FileMessage` class that is meant to allow developers to interact with `.eml` files using the same methods as the `Message` class. 

**Usage:**

```php
use DirectoryTree\ImapEngine\FileMessage;

$message = new FileMessage(
    file_get_contents('../email.eml')
);

$message->from(); // Address

// ...
```