### PR TITLE
Add how to import Mailbox to example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ ImapEngine provides a simple, fluent API for working with IMAP mailboxes, messag
 To connect to a mailbox, create a new `Mailbox` instance with the configuration options:
 
 ```php
+use DirectoryTree\ImapEngine\Mailbox;
 $mailbox = new Mailbox([
     'port' => 993,
     'username' => '...',


### PR DESCRIPTION
The examples never showed how to actually import Mailbox, I had to check the source code to actually learn how to make
```php
$mailbox = new Mailbox(...);
```
work.