### PR TITLE
Improve mbox matching with Google Takeout format

### DIFF
--- a/src/Mbox.php
+++ b/src/Mbox.php
@@ -22,7 +22,7 @@ class Mbox
         .'(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+' // Day
         .'(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+' // Month
         .'\d{1,2}\s+\d{2}:\d{2}:\d{2}' // Time (HH:MM:SS)
-        .'(?:\s+[+-]\d{4})?' // Optionally match "+0000"
+        .'(?:\s+[+-]\d{4})?' // Optional Timezone ("+0000")
         .'\s+\d{4}/' // Year
     ): Generator {
         if (! $handle = fopen($this->filepath, 'r')) {

--- a/src/Mbox.php
+++ b/src/Mbox.php
@@ -18,7 +18,12 @@ class Mbox
      * Get the messages from the mbox file.
      */
     public function messages(
-        string $delimiter = '/^From \\S+\\s+(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s+\\d{1,2}\\s+\\d{2}:\\d{2}:\\d{2}\\s+\\d{4}/'
+        string $delimiter = '/^From\s+\S+\s+' // From
+        .'(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+' // Day
+        .'(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+' // Month
+        .'\d{1,2}\s+\d{2}:\d{2}:\d{2}' // Time (HH:MM:SS)
+        .'(?:\s+[+-]\d{4})?' // Optionally match "+0000"
+        .'\s+\d{4}/' // Year
     ): Generator {
         if (! $handle = fopen($this->filepath, 'r')) {
             throw new RuntimeException('Failed to open mbox file: '.$this->filepath);

--- a/tests/Stubs/mailbox.mbox
+++ b/tests/Stubs/mailbox.mbox
@@ -495,7 +495,7 @@ Seattle, WA 98195-5065
 mmh1@uw.edu
 
 
-From nobody Thu May  5 21:08:05 2011
+From nobody Tue Mar 11 01:31:25 +0000 2025
 Return-Path: <mmh1@uw.edu>
 Received: from mx1.cac.washington.edu (mx1.cac.washington.edu [140.142.32.206])
 	by mailman2.u.washington.edu (8.14.4+UW11.03/8.14.4+UW11.03) with ESMTP


### PR DESCRIPTION
As suggested by @chrootchad, this PR improves the default delimiter to support matching against Google's Takeout format:

```
From 182625943453455425@xxx Tue Mar 11 01:31:25 +0000 2025
```