### PR TITLE
Handle moving messages when server only has UIDPLUS capability

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -97,7 +97,7 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
     public function idle(callable $callback, ?callable $query = null, int $timeout = 300): void
     {
         if (! in_array('IDLE', $this->mailbox->capabilities())) {
-            throw new ImapCapabilityException('IMAP server does not support IDLE');
+            throw new ImapCapabilityException('Unable to IDLE. IMAP server does not support IDLE capability.');
         }
 
         // The message query to use when fetching messages.

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -14,11 +14,6 @@ use JsonSerializable;
 class Folder implements Arrayable, FolderInterface, JsonSerializable
 {
     /**
-     * The folder's cached capabilities.
-     */
-    protected array $capabilities;
-
-    /**
      * Constructor.
      */
     public function __construct(

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -96,7 +96,7 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
      */
     public function idle(callable $callback, ?callable $query = null, int $timeout = 300): void
     {
-        if (! $this->hasCapability('IDLE')) {
+        if (! in_array('IDLE', $this->mailbox->capabilities())) {
             throw new ImapCapabilityException('IMAP server does not support IDLE');
         }
 
@@ -196,22 +196,6 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
     public function delete(): void
     {
         $this->mailbox->connection()->delete($this->path);
-    }
-
-    /**
-     * Determine if the mailbox has the given capability.
-     */
-    protected function hasCapability(string $capability): bool
-    {
-        return in_array($capability, $this->capabilities());
-    }
-
-    /**
-     * Get and in-memory cache the mailboxes's capabilities.
-     */
-    protected function capabilities(): array
-    {
-        return $this->capabilities ??= $this->mailbox->capabilities();
     }
 
     /**

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -203,7 +203,7 @@ class Mailbox implements MailboxInterface
     {
         return $this->capabilities ??= array_map(
             fn (Atom $token) => $token->value,
-            $this->connection()->capability()->tokensAfter(1)
+            $this->connection()->capability()->tokensAfter(2)
         );
     }
 

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -33,6 +33,13 @@ class Mailbox implements MailboxInterface
     ];
 
     /**
+     * The cached mailbox capabilities.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc9051#section-6.1.1
+     */
+    protected ?array $capabilities = null;
+
+    /**
      * The currently selected folder.
      */
     protected ?FolderInterface $selected = null;
@@ -194,7 +201,7 @@ class Mailbox implements MailboxInterface
      */
     public function capabilities(): array
     {
-        return array_map(
+        return $this->capabilities ??= array_map(
             fn (Atom $token) => $token->value,
             $this->connection()->capability()->tokensAfter(1)
         );

--- a/src/Message.php
+++ b/src/Message.php
@@ -316,7 +316,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
 
             default:
                 throw new ImapCapabilityException(
-                    'Unable to move message. Server does not support MOVE or UIDPLUS capabilities.'
+                    'Unable to move message. Server does not support MOVE or UIDPLUS capabilities'
                 );
         }
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -316,7 +316,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
 
             default:
                 throw new ImapCapabilityException(
-                    'Unable to move message. Server does not support MOVE or UIDPLUS capabilities'
+                    'Unable to move message. IMAP server does not support MOVE or UIDPLUS capabilities'
                 );
         }
     }

--- a/tests/Integration/MailboxTest.php
+++ b/tests/Integration/MailboxTest.php
@@ -18,7 +18,6 @@ test('capabilities', function () {
     $mailbox = mailbox();
 
     expect($mailbox->capabilities())->toBe([
-        'CAPABILITY',
         'IMAP4rev1',
         'LITERAL+',
         'UIDPLUS',

--- a/tests/Unit/MailboxTest.php
+++ b/tests/Unit/MailboxTest.php
@@ -119,3 +119,23 @@ test('inbox', function () {
     expect($folder->path())->toBe('INBOX');
     expect($folder->flags())->toBe(['\\HasNoChildren']);
 });
+
+test('capabilities', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* CAPABILITY IMAP4rev1 STARTTLS AUTH=PLAIN',
+        'TAG2 OK CAPABILITY completed',
+    ]));
+
+    expect($mailbox->capabilities())->toBe([
+        'IMAP4rev1',
+        'STARTTLS',
+        'AUTH=PLAIN',
+    ]);
+});

--- a/tests/Unit/MessageTest.php
+++ b/tests/Unit/MessageTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use DirectoryTree\ImapEngine\Connection\ImapConnection;
+use DirectoryTree\ImapEngine\Enums\ImapFlag;
+use DirectoryTree\ImapEngine\Exceptions\ImapCapabilityException;
+use DirectoryTree\ImapEngine\Folder;
+use DirectoryTree\ImapEngine\Mailbox;
+use DirectoryTree\ImapEngine\Message;
+
+test('it moves message using MOVE when capable', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* CAPABILITY IMAP4rev1 STARTTLS MOVE AUTH=PLAIN',
+        'TAG2 OK CAPABILITY completed',
+        'TAG3 OK MOVE completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $message = new Message($folder, 1, [], 'header', 'body');
+
+    $message->move('INBOX.Sent');
+})->throwsNoExceptions();
+
+test('it copies and then deletes message using UIDPLUS when incapable of MOVE', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* CAPABILITY IMAP4rev1 STARTTLS UIDPLUS AUTH=PLAIN',
+        'TAG2 OK CAPABILITY completed',
+        'TAG3 OK UID MOVE completed',
+        'TAG4 OK COPY completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $message = new Message($folder, 1, [], 'header', 'body');
+
+    $message->move('INBOX.Sent');
+})->throwsNoExceptions();
+
+test('it throws exception when server does not support MOVE or UIDPLUS capabilities', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* CAPABILITY IMAP4rev1 STARTTLS AUTH=PLAIN',
+        'TAG2 OK CAPABILITY completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $message = new Message($folder, 1, [], 'header', 'body');
+
+    $message->move('INBOX.Sent');
+})->throws(ImapCapabilityException::class);
+
+test('it can mark and unmark a message as flagged', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* CAPABILITY IMAP4rev1 STARTTLS AUTH=PLAIN',
+        'TAG2 OK CAPABILITY completed',
+        'TAG3 OK STORE completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $message = new Message($folder, 1, [], 'header', 'body');
+
+    expect($message->isFlagged())->toBeFalse();
+    expect($message->flags())->not->toContain('\\Flagged');
+
+    $message->markFlagged();
+
+    expect($message->isFlagged())->toBeTrue();
+    expect($message->flags())->toContain('\\Flagged');
+    expect($message->hasFlag(ImapFlag::Flagged))->toBeTrue();
+
+    $message->unmarkFlagged();
+
+    expect($message->isFlagged())->toBeFalse();
+    expect($message->flags())->not->toContain('\\Flagged');
+    expect($message->hasFlag(ImapFlag::Flagged))->toBeFalse();
+});


### PR DESCRIPTION
Closes #38 

This PR implements a secondary method of moving messages into different folders if the server does not support MOVE capability, but UIDPLUS.