### PR TITLE
Add generics annotations for better IDE support

### DIFF
--- a/src/Collections/FolderCollection.php
+++ b/src/Collections/FolderCollection.php
@@ -2,6 +2,10 @@
 
 namespace DirectoryTree\ImapEngine\Collections;
 
+use DirectoryTree\ImapEngine\FolderInterface;
 use Illuminate\Support\Collection;
 
+/**
+ * @template-extends Collection<array-key, FolderInterface>
+ */
 class FolderCollection extends Collection {}

--- a/src/Collections/MessageCollection.php
+++ b/src/Collections/MessageCollection.php
@@ -5,6 +5,9 @@ namespace DirectoryTree\ImapEngine\Collections;
 use DirectoryTree\ImapEngine\Message;
 use DirectoryTree\ImapEngine\MessageInterface;
 
+/**
+ * @template-extends PaginatedCollection<array-key, MessageInterface>
+ */
 class MessageCollection extends PaginatedCollection
 {
     /**

--- a/src/Collections/PaginatedCollection.php
+++ b/src/Collections/PaginatedCollection.php
@@ -5,6 +5,12 @@ namespace DirectoryTree\ImapEngine\Collections;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 
+/**
+ * @template TKey of array-key
+ * @template-covariant TValue
+ *
+ * @template-extends Collection<TKey, TValue>
+ */
 class PaginatedCollection extends Collection
 {
     /**
@@ -14,6 +20,8 @@ class PaginatedCollection extends Collection
 
     /**
      * Paginate the current collection.
+     * 
+     * @return LengthAwarePaginator<TKey, TValue>
      */
     public function paginate(int $perPage = 15, ?int $page = null, string $pageName = 'page', bool $prepaginated = false): LengthAwarePaginator
     {
@@ -26,6 +34,8 @@ class PaginatedCollection extends Collection
 
     /**
      * Create a new length-aware paginator instance.
+     * 
+     *  @return LengthAwarePaginator<TKey, TValue>
      */
     protected function paginator(Collection $items, int $total, int $perPage, ?int $currentPage, string $pageName): LengthAwarePaginator
     {

--- a/src/Collections/ResponseCollection.php
+++ b/src/Collections/ResponseCollection.php
@@ -3,14 +3,19 @@
 namespace DirectoryTree\ImapEngine\Collections;
 
 use DirectoryTree\ImapEngine\Connection\Responses\ContinuationResponse;
-use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
+use DirectoryTree\ImapEngine\Connection\Responses\Response;use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use Illuminate\Support\Collection;
 
+/**
+ * @template-extends Collection<array-key, Response>
+ */
 class ResponseCollection extends Collection
 {
     /**
      * Filter the collection to only tagged responses.
+     * 
+     * @return self<array-key, TaggedResponse>
      */
     public function tagged(): self
     {
@@ -19,6 +24,8 @@ class ResponseCollection extends Collection
 
     /**
      * Filter the collection to only untagged responses.
+     *
+     * @return self<array-key, UntaggedResponse>
      */
     public function untagged(): self
     {
@@ -27,6 +34,8 @@ class ResponseCollection extends Collection
 
     /**
      * Filter the collection to only continuation responses.
+     * 
+     *  @return self<array-key, ContinuationResponse>
      */
     public function continuation(): self
     {

--- a/src/Collections/ResponseCollection.php
+++ b/src/Collections/ResponseCollection.php
@@ -3,7 +3,8 @@
 namespace DirectoryTree\ImapEngine\Collections;
 
 use DirectoryTree\ImapEngine\Connection\Responses\ContinuationResponse;
-use DirectoryTree\ImapEngine\Connection\Responses\Response;use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
+use DirectoryTree\ImapEngine\Connection\Responses\Response;
+use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use Illuminate\Support\Collection;
 

--- a/src/Pagination/LengthAwarePaginator.php
+++ b/src/Pagination/LengthAwarePaginator.php
@@ -6,7 +6,6 @@ use DirectoryTree\ImapEngine\Support\ForwardsCalls;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use JsonSerializable;
-use Psalm\Type\Atomic\TValueOf;
 
 /**
  * @template TKey of array-key

--- a/src/Pagination/LengthAwarePaginator.php
+++ b/src/Pagination/LengthAwarePaginator.php
@@ -5,8 +5,14 @@ namespace DirectoryTree\ImapEngine\Pagination;
 use DirectoryTree\ImapEngine\Support\ForwardsCalls;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
-use JsonSerializable;
+use JsonSerializable;use Psalm\Type\Atomic\TValueOf;
 
+/**
+ * @template TKey of array-key
+ * @template-covariant TValue
+ *
+ * @template-implements Arrayable<TKey, TValue>
+ */
 class LengthAwarePaginator implements Arrayable, JsonSerializable
 {
     use ForwardsCalls;
@@ -38,6 +44,8 @@ class LengthAwarePaginator implements Arrayable, JsonSerializable
 
     /**
      * Get the items being paginated.
+     * 
+     * @return Collection<TKey, TValue>
      */
     public function items(): Collection
     {

--- a/src/Pagination/LengthAwarePaginator.php
+++ b/src/Pagination/LengthAwarePaginator.php
@@ -5,7 +5,8 @@ namespace DirectoryTree\ImapEngine\Pagination;
 use DirectoryTree\ImapEngine\Support\ForwardsCalls;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
-use JsonSerializable;use Psalm\Type\Atomic\TValueOf;
+use JsonSerializable;
+use Psalm\Type\Atomic\TValueOf;
 
 /**
  * @template TKey of array-key


### PR DESCRIPTION
Now PHPStorm knows what was returned by collections and provides autocompletion (notice type hint in bottom-right corner):
![изображение](https://github.com/user-attachments/assets/054f3d77-37bf-4313-a0b7-af7f681e9688)


I did not run tests because there are only annotations.