### PR TITLE
Fake mailbox queries fail when adding any query clauses

### DIFF
--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -13,18 +13,16 @@ use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
 use DirectoryTree\ImapEngine\Exceptions\ImapCommandException;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
-use DirectoryTree\ImapEngine\Support\ForwardsCalls;
 use DirectoryTree\ImapEngine\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
-use Illuminate\Support\Traits\Conditionable;
 
 /**
  * @mixin \DirectoryTree\ImapEngine\Connection\ImapQueryBuilder
  */
 class MessageQuery implements MessageQueryInterface
 {
-    use Conditionable, ForwardsCalls, QueriesMessages;
+    use QueriesMessages;
 
     /**
      * Constructor.

--- a/src/QueriesMessages.php
+++ b/src/QueriesMessages.php
@@ -3,9 +3,13 @@
 namespace DirectoryTree\ImapEngine;
 
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
+use DirectoryTree\ImapEngine\Support\ForwardsCalls;
+use Illuminate\Support\Traits\Conditionable;
 
 trait QueriesMessages
 {
+    use Conditionable, ForwardsCalls;
+
     /**
      * The query builder instance.
      */

--- a/src/Testing/FakeMessageQuery.php
+++ b/src/Testing/FakeMessageQuery.php
@@ -3,6 +3,7 @@
 namespace DirectoryTree\ImapEngine\Testing;
 
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
+use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\MessageInterface;
 use DirectoryTree\ImapEngine\MessageQueryInterface;
@@ -17,7 +18,8 @@ class FakeMessageQuery implements MessageQueryInterface
      * Constructor.
      */
     public function __construct(
-        protected FakeFolder $folder
+        protected FakeFolder $folder,
+        protected ImapQueryBuilder $query = new ImapQueryBuilder
     ) {}
 
     /**

--- a/tests/Unit/Testing/FakeFolderTest.php
+++ b/tests/Unit/Testing/FakeFolderTest.php
@@ -71,6 +71,7 @@ test('it can set flags', function () {
 
 test('it can set mailbox', function () {
     $folder = new FakeFolder('INBOX');
+
     $mailbox = new FakeMailbox(['host' => 'imap.example.com']);
 
     $folder->setMailbox($mailbox);
@@ -80,9 +81,11 @@ test('it can set mailbox', function () {
 
 test('it can set messages', function () {
     $folder = new FakeFolder('INBOX');
-    $messages = [new FakeMessage(1), new FakeMessage(2)];
 
-    $folder->setMessages($messages);
+    $folder->setMessages([
+        new FakeMessage(1),
+        new FakeMessage(2),
+    ]);
 
     expect($folder->messages()->count())->toBe(2);
 });
@@ -95,15 +98,16 @@ test('it can set delimiter', function () {
     expect($folder->delimiter())->toBe('.');
 });
 
-it('can query messages from a fake mailbox folder', function () {
-    $message1 = new FakeMessage(1, [''], 'Message 1');
-    $message2 = new FakeMessage(2, [''], 'Message 2');
-    $message3 = new FakeMessage(3, ['\\Seen'], 'Message 3');
+test('it can query messages from a fake mailbox folder', function () {
+    $folder = new FakeFolder('inbox', ['\\HasNoChildren'], [
+        new FakeMessage(1, [''], 'Message 1'),
+        new FakeMessage(2, [''], 'Message 2'),
+        new FakeMessage(3, ['\\Seen'], 'Message 3'),
+    ]);
 
-    $folder = new FakeFolder('inbox', ['\\HasNoChildren'], [$message1, $message2, $message3]);
-
+    // These should all have the same count because
+    // no filtering should actually take place
     expect($folder->messages()->count())->toBe(3);
-
-    expect($folder->messages()->where('Unseen')->count())->toBe(2);
-    expect($folder->messages()->where('Seen')->count())->toBe(1);
+    expect($folder->messages()->where('Unseen')->count())->toBe(3);
+    expect($folder->messages()->where('Seen')->count())->toBe(3);
 });

--- a/tests/Unit/Testing/FakeFolderTest.php
+++ b/tests/Unit/Testing/FakeFolderTest.php
@@ -94,3 +94,16 @@ test('it can set delimiter', function () {
 
     expect($folder->delimiter())->toBe('.');
 });
+
+it('can query messages from a fake mailbox folder', function () {
+    $message1 = new FakeMessage(1, [''], 'Message 1');
+    $message2 = new FakeMessage(2, [''], 'Message 2');
+    $message3 = new FakeMessage(3, ['\\Seen'], 'Message 3');
+
+    $folder = new FakeFolder('inbox', ['\\HasNoChildren'], [$message1, $message2, $message3]);
+
+    expect($folder->messages()->count())->toBe(3);
+
+    expect($folder->messages()->where('Unseen')->count())->toBe(2);
+    expect($folder->messages()->where('Seen')->count())->toBe(1);
+});


### PR DESCRIPTION
I think I've found a bug, using `$folder->messages()->where('Unseen')` works, but if I fake it it doesn't work.
Idk if this should work or if there's another way to test it out.