### PR TITLE
Fix `flag()` method signature

### DIFF
--- a/src/FileMessage.php
+++ b/src/FileMessage.php
@@ -2,6 +2,7 @@
 
 namespace DirectoryTree\ImapEngine;
 
+use BackedEnum;
 use BadMethodCallException;
 
 class FileMessage implements MessageInterface
@@ -26,7 +27,7 @@ class FileMessage implements MessageInterface
     /**
      * {@inheritDoc}
      */
-    public function flag(mixed $flag, string $operation, bool $expunge = false): void
+    public function flag(BackedEnum|string $flag, string $operation, bool $expunge = false): void
     {
         throw new BadMethodCallException('FileMessage does not support flagging');
     }

--- a/src/FlaggableInterface.php
+++ b/src/FlaggableInterface.php
@@ -121,5 +121,5 @@ interface FlaggableInterface
     /**
      * Add or remove a flag from the message.
      */
-    public function flag(mixed $flag, string $operation, bool $expunge = false): void;
+    public function flag(BackedEnum|string $flag, string $operation, bool $expunge = false): void;
 }

--- a/src/HasFlags.php
+++ b/src/HasFlags.php
@@ -184,5 +184,5 @@ trait HasFlags
     /**
      * {@inheritDoc}
      */
-    abstract public function flag(mixed $flag, string $operation, bool $expunge = false): void;
+    abstract public function flag(BackedEnum|string $flag, string $operation, bool $expunge = false): void;
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -2,6 +2,7 @@
 
 namespace DirectoryTree\ImapEngine;
 
+use BackedEnum;
 use DirectoryTree\ImapEngine\Connection\Responses\MessageResponseParser;
 use DirectoryTree\ImapEngine\Exceptions\ImapCapabilityException;
 use DirectoryTree\ImapEngine\Support\Str;
@@ -103,7 +104,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     /**
      * Add or remove a flag from the message.
      */
-    public function flag(mixed $flag, string $operation, bool $expunge = false): void
+    public function flag(BackedEnum|string $flag, string $operation, bool $expunge = false): void
     {
         $flag = Str::enum($flag);
 

--- a/src/Testing/FakeMessage.php
+++ b/src/Testing/FakeMessage.php
@@ -2,6 +2,7 @@
 
 namespace DirectoryTree\ImapEngine\Testing;
 
+use BackedEnum;
 use DirectoryTree\ImapEngine\HasFlags;
 use DirectoryTree\ImapEngine\HasParsedMessage;
 use DirectoryTree\ImapEngine\MessageInterface;
@@ -42,7 +43,7 @@ class FakeMessage implements MessageInterface
     /**
      * {@inheritDoc}
      */
-    public function flag(mixed $flag, string $operation, bool $expunge = false): void
+    public function flag(BackedEnum|string $flag, string $operation, bool $expunge = false): void
     {
         $flag = Str::enum($flag);
 


### PR DESCRIPTION
The `flag` method incorrectly accepts `mixed`, which can imply that it may accept an `array` or `collection` of flags.

This change makes the `$flag` parameter consistent with the `hasFlags` method.