### PR TITLE
Ensure message UID sorting is consistent

### DIFF
--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -263,19 +263,24 @@ class MessageQuery implements MessageQueryInterface
             'desc' => $messages->sortDesc(SORT_NUMERIC),
         };
 
-        $uids = $messages->forPage($this->page, $this->limit)->values();
+        $uids = $messages->forPage($this->page, $this->limit)
+            ->values()
+            ->all();
 
         $flags = $this->fetchFlags ? $this->connection()
             ->flags($uids)
-            ->mapWithKeys(MessageResponseParser::getFlags(...))->all() : [];
+            ->mapWithKeys(MessageResponseParser::getFlags(...))
+            ->all() : [];
 
         $headers = $this->fetchHeaders ? $this->connection()
             ->bodyHeader($uids, $this->fetchAsUnread)
-            ->mapWithKeys(MessageResponseParser::getBodyHeader(...))->all() : [];
+            ->mapWithKeys(MessageResponseParser::getBodyHeader(...))
+            ->all() : [];
 
         $contents = $this->fetchBody ? $this->connection()
             ->bodyText($uids, $this->fetchAsUnread)
-            ->mapWithKeys(MessageResponseParser::getBodyText(...))->all() : [];
+            ->mapWithKeys(MessageResponseParser::getBodyText(...))
+            ->all() : [];
 
         return [
             'uids' => $uids,

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -258,9 +258,10 @@ class MessageQuery implements MessageQueryInterface
      */
     protected function fetch(Collection $messages): array
     {
-        if ($this->fetchOrder === 'desc') {
-            $messages = $messages->reverse();
-        }
+        $messages = match ($this->fetchOrder) {
+            'asc' => $messages->sort(SORT_NUMERIC),
+            'desc' => $messages->sortDesc(SORT_NUMERIC),
+        };
 
         $uids = $messages->forPage($this->page, $this->limit)->toArray();
 

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -263,7 +263,7 @@ class MessageQuery implements MessageQueryInterface
             'desc' => $messages->sortDesc(SORT_NUMERIC),
         };
 
-        $uids = $messages->forPage($this->page, $this->limit)->toArray();
+        $uids = $messages->forPage($this->page, $this->limit)->values();
 
         $flags = $this->fetchFlags ? $this->connection()
             ->flags($uids)

--- a/tests/Integration/MailboxTest.php
+++ b/tests/Integration/MailboxTest.php
@@ -17,7 +17,7 @@ test('inbox', function () {
 test('capabilities', function () {
     $mailbox = mailbox();
 
-    expect($mailbox->capabilities())->toBe([
+    expect($mailbox->capabilities())->toEqualCanonicalizing([
         'IMAP4rev1',
         'LITERAL+',
         'UIDPLUS',

--- a/tests/Integration/MailboxTest.php
+++ b/tests/Integration/MailboxTest.php
@@ -17,7 +17,7 @@ test('inbox', function () {
 test('capabilities', function () {
     $mailbox = mailbox();
 
-    expect($mailbox->capabilities())->toEqualCanonicalizing([
+    expect(array_flip($mailbox->capabilities()))->toHaveKeys([
         'IMAP4rev1',
         'LITERAL+',
         'UIDPLUS',


### PR DESCRIPTION
Closes #92

As discovered by @liuch, we're assuming IMAP UIDs will always return in ascending order, which isn't the case with all providers. This PR ensures sorting is done on retrieved UIDs in a consistent manner across all IMAP servers.