### PR TITLE
Parse `Number` tokens in tokenizer

### DIFF
--- a/src/Connection/ImapTokenizer.php
+++ b/src/Connection/ImapTokenizer.php
@@ -9,6 +9,7 @@ use DirectoryTree\ImapEngine\Connection\Tokens\EmailAddress;
 use DirectoryTree\ImapEngine\Connection\Tokens\ListClose;
 use DirectoryTree\ImapEngine\Connection\Tokens\ListOpen;
 use DirectoryTree\ImapEngine\Connection\Tokens\Literal;
+use DirectoryTree\ImapEngine\Connection\Tokens\Number;
 use DirectoryTree\ImapEngine\Connection\Tokens\QuotedString;
 use DirectoryTree\ImapEngine\Connection\Tokens\ResponseCodeClose;
 use DirectoryTree\ImapEngine\Connection\Tokens\ResponseCodeOpen;
@@ -118,6 +119,11 @@ class ImapTokenizer
         // Check for literal block open.
         if ($char === '{') {
             return $this->readLiteral();
+        }
+
+        // Check for number.
+        if (ctype_digit($char)) {
+            return $this->readNumber();
         }
 
         // Otherwise, parse an atom.
@@ -298,6 +304,36 @@ class ImapTokenizer
         }
 
         return new Literal($literal);
+    }
+
+    /**
+     * Reads a number token.
+     *
+     * Numbers are sequences of digits.
+     */
+    protected function readNumber(): Number
+    {
+        $value = '';
+
+        while (true) {
+            $this->ensureBuffer(1);
+
+            $char = $this->currentChar();
+
+            if ($char === null) {
+                break;
+            }
+
+            if (! ctype_digit($char)) {
+                break;
+            }
+
+            $value .= $char;
+
+            $this->advance();
+        }
+
+        return new Number($value);
     }
 
     /**

--- a/src/Connection/Tokens/Number.php
+++ b/src/Connection/Tokens/Number.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace DirectoryTree\ImapEngine\Connection\Tokens;
+
+class Number extends Token {}

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -8,7 +8,7 @@ use DirectoryTree\ImapEngine\Connection\ConnectionInterface;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Connection\Responses\MessageResponseParser;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
-use DirectoryTree\ImapEngine\Connection\Tokens\Atom;
+use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
 use DirectoryTree\ImapEngine\Exceptions\ImapCommandException;
@@ -305,7 +305,7 @@ class MessageQuery implements MessageQueryInterface
         ]);
 
         return new Collection(array_map(
-            fn (Atom $token) => $token->value,
+            fn (Token $token) => $token->value,
             $response->tokensAfter(2)
         ));
     }

--- a/tests/Unit/Connection/ImapTokenizerTest.php
+++ b/tests/Unit/Connection/ImapTokenizerTest.php
@@ -335,6 +335,28 @@ test('tokenizer parsers properly', function (array|string $feed, array $tokens) 
     ],
 ]);
 
+test('tokenizer handles edge cases', function (string $feed, Token ...$expectedTokens) {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed($feed);
+
+    $tokenizer = new ImapTokenizer($stream);
+
+    foreach ($expectedTokens as $expectedToken) {
+        $actualToken = $tokenizer->nextToken();
+
+        expect($actualToken)->toBeInstanceOf(get_class($expectedToken));
+        expect($actualToken->value)->toBe($expectedToken->value);
+    }
+})->with([
+    ['UID 48273)', new Atom('UID'), new Number('48273'), new ListClose(')')],
+    ['* 23 EXISTS', new Atom('*'), new Number('23'), new Atom('EXISTS')],
+    ['OK (0.002 secs)', new Atom('OK'), new ListOpen('('), new Atom('0.002'), new Atom('secs'), new ListClose(')')],
+    ['OK 404NotFound', new Atom('OK'), new Atom('404NotFound')],
+    ['A1 OK [UIDNEXT 1000]', new Atom('A1'), new Atom('OK'), new ResponseCodeOpen('['), new Atom('UIDNEXT'), new Number('1000'), new ResponseCodeClose(']')],
+]);
+
 test('all tokens implement the token interface', function (string $data) {
     $stream = new FakeStream;
     $stream->open();

--- a/tests/Unit/Connection/ImapTokenizerTest.php
+++ b/tests/Unit/Connection/ImapTokenizerTest.php
@@ -8,6 +8,7 @@ use DirectoryTree\ImapEngine\Connection\Tokens\EmailAddress;
 use DirectoryTree\ImapEngine\Connection\Tokens\ListClose;
 use DirectoryTree\ImapEngine\Connection\Tokens\ListOpen;
 use DirectoryTree\ImapEngine\Connection\Tokens\Literal;
+use DirectoryTree\ImapEngine\Connection\Tokens\Number;
 use DirectoryTree\ImapEngine\Connection\Tokens\QuotedString;
 use DirectoryTree\ImapEngine\Connection\Tokens\ResponseCodeClose;
 use DirectoryTree\ImapEngine\Connection\Tokens\ResponseCodeOpen;
@@ -257,7 +258,7 @@ test('tokenizer parses tagged response with response codes', function () {
     expect($token->value)->toBe('UIDNEXT');
 
     $token = $tokenizer->nextToken();
-    expect($token)->toBeInstanceOf(Atom::class);
+    expect($token)->toBeInstanceOf(Number::class);
     expect($token->value)->toBe('1000');
 
     $token = $tokenizer->nextToken();


### PR DESCRIPTION
This PR introduces the `Number` token to represent the `number` data type as described in the IMAP RFC:

https://datatracker.ietf.org/doc/html/rfc9051#section-4.2