### PR TITLE
Add ability to break out of idle using timeout callback

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -2,6 +2,7 @@
 
 namespace DirectoryTree\ImapEngine;
 
+use Closure;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
@@ -92,10 +93,15 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
     /**
      * {@inheritDoc}
      */
-    public function idle(callable $callback, ?callable $query = null, int $timeout = 300): void
+    public function idle(callable $callback, ?callable $query = null, callable|int $timeout = 300): void
     {
         if (! in_array('IDLE', $this->mailbox->capabilities())) {
             throw new ImapCapabilityException('Unable to IDLE. IMAP server does not support IDLE capability.');
+        }
+
+        // Normalize timeout into a closure.
+        if (is_callable($timeout) && ! $timeout instanceof Closure) {
+            $timeout = $timeout(...);
         }
 
         // The message query to use when fetching messages.

--- a/src/FolderInterface.php
+++ b/src/FolderInterface.php
@@ -44,7 +44,7 @@ interface FolderInterface
     /**
      * Begin idling on the current folder.
      */
-    public function idle(callable $callback, ?callable $query = null, int $timeout = 300): void;
+    public function idle(callable $callback, ?callable $query = null, callable|int $timeout = 300): void;
 
     /**
      * Move or rename the current folder.

--- a/src/Idle.php
+++ b/src/Idle.php
@@ -160,7 +160,7 @@ class Idle
     protected function getNextTimeout(): CarbonInterface|false
     {
         if (is_numeric($seconds = value($this->timeout))) {
-            return Carbon::now()->addSeconds($seconds);
+            return Carbon::now()->addSeconds(abs($seconds));
         }
 
         return false;

--- a/src/Idle.php
+++ b/src/Idle.php
@@ -150,7 +150,7 @@ class Idle
     protected function idle(CarbonInterface $ttl): Generator
     {
         yield from $this->mailbox->connection()->idle(
-            (int) Carbon::now()->diffInSeconds($ttl)
+            (int) Carbon::now()->diffInSeconds($ttl, true)
         );
     }
 

--- a/src/Testing/FakeFolder.php
+++ b/src/Testing/FakeFolder.php
@@ -89,7 +89,7 @@ class FakeFolder implements FolderInterface
     /**
      * {@inheritDoc}
      */
-    public function idle(callable $callback, ?callable $query = null, int $timeout = 300): void
+    public function idle(callable $callback, ?callable $query = null, callable|int $timeout = 300): void
     {
         foreach ($this->messages as $message) {
             $callback($message);


### PR DESCRIPTION
Closes #97

This PR adds the ability to break out of mailbox idle by supplying a callback into the `timeout` parameter.

A `timeout` callback is called for each iteration of the idle loop, allowing it to effectively break out of it.

- Returning `false` from the callback will result in the idle cancelled.
- Returning a number from the callback will result in the number being used as the timeout for the upcoming idle.

```php
$loop = 0;

$mailbox->inbox()->idle(
    callback: function (Message $message) {
        // ...
    },
    timeout: function () use (&$loop) {
        if ($loop > 5) {
            return false; // break after 5 IDLE's
        }

        try {
            return 100; // timeout in seconds
        } finally {
            $loop++;
        }
    }
);
```