### PR TITLE
Add ability to fetch messages by UID sequence range

### DIFF
--- a/src/Connection/ImapQueryBuilder.php
+++ b/src/Connection/ImapQueryBuilder.php
@@ -230,11 +230,9 @@ class ImapQueryBuilder
     /**
      * Add a where "UID" clause to the query.
      */
-    public function uid(int|string|array $uid): static
+    public function uid(int|string|array $from, int|float|null $to = null): static
     {
-        return $this->where(ImapSearchKey::Uid, new RawQueryValue(
-            Str::set(array_map('intval', (array) $uid))
-        ));
+        return $this->where(ImapSearchKey::Uid, new RawQueryValue(Str::set($from, $to)));
     }
 
     /**

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -77,7 +77,7 @@ class Str
     /**
      * Make a range set for use in a search command.
      */
-    public static function set(array|int $from, int|float|null $to = null): string
+    public static function set(int|string|array $from, int|float|string|null $to = null): string
     {
         // If $from is an array with multiple elements, return them as a comma-separated list.
         if (is_array($from) && count($from) > 1) {

--- a/tests/Unit/Connection/ImapQueryBuilderTest.php
+++ b/tests/Unit/Connection/ImapQueryBuilderTest.php
@@ -244,3 +244,43 @@ test('compiles multiple UID values without quotes', function () {
 
     expect($builder->toImap())->toBe('UID 2,3,5');
 });
+
+test('compiles UID range to infinity with from and to', function () {
+    $builder = new ImapQueryBuilder;
+
+    $builder->uid(2, INF);
+
+    expect($builder->toImap())->toBe('UID 2:*');
+});
+
+test('compiles UID range with upper bound with array', function () {
+    $builder = new ImapQueryBuilder;
+
+    $builder->uid([2, 5]);
+
+    expect($builder->toImap())->toBe('UID 2,5');
+});
+
+test('compiles UID range with upper bound with from and to', function () {
+    $builder = new ImapQueryBuilder;
+
+    $builder->uid(2, 5);
+
+    expect($builder->toImap())->toBe('UID 2:5');
+});
+
+test('compiles UID range with single value', function () {
+    $builder = new ImapQueryBuilder;
+
+    $builder->uid(2);
+
+    expect($builder->toImap())->toBe('UID 2');
+});
+
+test('compiles UID range with single value array', function () {
+    $builder = new ImapQueryBuilder;
+
+    $builder->uid([2]);
+
+    expect($builder->toImap())->toBe('UID 2');
+});

--- a/tests/Unit/Support/StrTest.php
+++ b/tests/Unit/Support/StrTest.php
@@ -5,8 +5,10 @@ use DirectoryTree\ImapEngine\Support\Str;
 
 test('set', function () {
     expect(Str::set(5, 10))->toBe('5:10');
+    expect(Str::set('5', '10'))->toBe('5:10');
     expect(Str::set(5, INF))->toBe('5:*');
     expect(Str::set([5, 10]))->toBe('5,10');
+    expect(Str::set(['5', '10']))->toBe('5,10');
     expect(Str::set([5]))->toBe('5');
     expect(Str::set(5))->toBe('5');
 });


### PR DESCRIPTION
Closes #98

This PR adds the ability to fetch messages with a given UID range. Example:

```php
$mailbox->inbox()->messages()
    ->withHeaders()
    ->uid(5, INF) // Generates "UID 5:*"
    ->get();
```