### PR TITLE
Implement PHPStan up to level 2

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 1
+	level: 2
 	ignoreErrors:
 	    -
 	        identifier: new.static

--- a/src/Collections/PaginatedCollection.php
+++ b/src/Collections/PaginatedCollection.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Collection;
 /**
  * @template TKey of array-key
  *
- * @template-covariant TValue
+ * @template TValue
  *
  * @template-extends Collection<TKey, TValue>
  */

--- a/src/HasParsedMessage.php
+++ b/src/HasParsedMessage.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use DirectoryTree\ImapEngine\Exceptions\RuntimeException;
 use GuzzleHttp\Psr7\Utils;
+use ZBateson\MailMimeParser\Header\DateHeader;
 use ZBateson\MailMimeParser\Header\HeaderConsts;
 use ZBateson\MailMimeParser\Header\IHeader;
 use ZBateson\MailMimeParser\Header\IHeaderPart;
@@ -27,8 +28,9 @@ trait HasParsedMessage
      */
     public function date(): ?CarbonInterface
     {
-        if ($date = $this->header(HeaderConsts::DATE)?->getDateTime()) {
-            return Carbon::instance($date);
+        $dateHeader = $this->header(HeaderConsts::DATE);
+        if ($dateHeader instanceof DateHeader) {
+            return Carbon::instance($dateHeader->getDateTime());
         }
 
         return null;

--- a/src/Idle.php
+++ b/src/Idle.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Closure;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
+use DirectoryTree\ImapEngine\Connection\Tokens\Atom;
 use DirectoryTree\ImapEngine\Exceptions\Exception;
 use DirectoryTree\ImapEngine\Exceptions\ImapConnectionClosedException;
 use DirectoryTree\ImapEngine\Exceptions\ImapConnectionTimedOutException;
@@ -59,7 +60,9 @@ class Idle
                 continue;
             }
 
-            if ($response->tokenAt(2)?->is('EXISTS')) {
+            $possibleExistsToken = $response->tokenAt(2);
+
+            if ($possibleExistsToken instanceof Atom && $possibleExistsToken->is('EXISTS')) {
                 $msgn = (int) $response->tokenAt(1)->value;
 
                 $callback($msgn);

--- a/src/Pagination/LengthAwarePaginator.php
+++ b/src/Pagination/LengthAwarePaginator.php
@@ -10,7 +10,7 @@ use JsonSerializable;
 /**
  * @template TKey of array-key
  *
- * @template-covariant TValue
+ * @template TValue
  *
  * @template-implements Arrayable<TKey, TValue>
  */


### PR DESCRIPTION
After level 1 follows level 2

Nothing too exciting here, i guess.

One thing I want to point out. I prefer to check for the right instance in runtime. I just found out you seem to prefer, to declare the type as it should be.

My runtime check makes sure it's the right instance while running
Your approach is valid, too. It should ideally never be different than expected... but it might be