### PR TITLE
Implement PHPStan up to level 3

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 2
+	level: 3
 	ignoreErrors:
 	    -
 	        identifier: new.static

--- a/src/Collections/MessageCollection.php
+++ b/src/Collections/MessageCollection.php
@@ -2,17 +2,18 @@
 
 namespace DirectoryTree\ImapEngine\Collections;
 
+use DirectoryTree\ImapEngine\Message;
 use DirectoryTree\ImapEngine\MessageInterface;
 
 /**
- * @template-extends PaginatedCollection<array-key, \DirectoryTree\ImapEngine\MessageInterface|\DirectoryTree\ImapEngine\Message>
+ * @template-extends PaginatedCollection<array-key, MessageInterface|Message>
  */
 class MessageCollection extends PaginatedCollection
 {
     /**
      * Find a message by its UID.
      *
-     * @return \DirectoryTree\ImapEngine\Message|null
+     * @return MessageInterface|null
      */
     public function find(int $uid): ?MessageInterface
     {
@@ -24,7 +25,7 @@ class MessageCollection extends PaginatedCollection
     /**
      * Find a message by its UID or throw an exception.
      *
-     * @return \DirectoryTree\ImapEngine\Message
+     * @return MessageInterface
      */
     public function findOrFail(int $uid): MessageInterface
     {

--- a/src/Collections/ResponseCollection.php
+++ b/src/Collections/ResponseCollection.php
@@ -9,7 +9,11 @@ use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use Illuminate\Support\Collection;
 
 /**
- * @template-extends Collection<array-key, Response>
+ * @template TKey of array-key
+ *
+ * @template-covariant TValue
+ *
+ * @extends Collection<array-key, TValue>
  */
 class ResponseCollection extends Collection
 {

--- a/src/Connection/ImapConnection.php
+++ b/src/Connection/ImapConnection.php
@@ -701,7 +701,8 @@ class ImapConnection implements ConnectionInterface
      */
     protected function assertTaggedResponse(string $tag, ?callable $exception = null): TaggedResponse
     {
-        return $this->assertNextResponse(
+        /** @var TaggedResponse $response */
+        $response =  $this->assertNextResponse(
             fn (Response $response) => (
                 $response instanceof TaggedResponse && $response->tag()->is($tag)
             ),
@@ -712,6 +713,7 @@ class ImapConnection implements ConnectionInterface
                 ImapCommandException::make($this->result->command(), $response)
             ),
         );
+        return $response;
     }
 
     /**

--- a/src/HasParsedMessage.php
+++ b/src/HasParsedMessage.php
@@ -13,6 +13,7 @@ use ZBateson\MailMimeParser\Header\IHeaderPart;
 use ZBateson\MailMimeParser\Header\Part\AddressPart;
 use ZBateson\MailMimeParser\Header\Part\ContainerPart;
 use ZBateson\MailMimeParser\Header\Part\NameValuePart;
+use ZBateson\MailMimeParser\IMessage;
 use ZBateson\MailMimeParser\Message as MailMimeMessage;
 use ZBateson\MailMimeParser\Message\IMessagePart;
 
@@ -21,7 +22,7 @@ trait HasParsedMessage
     /**
      * The parsed message.
      */
-    protected ?MailMimeMessage $parsed = null;
+    protected ?IMessage $parsed = null;
 
     /**
      * Get the message date and time.
@@ -224,7 +225,7 @@ trait HasParsedMessage
     /**
      * Parse the message into a MailMimeMessage instance.
      */
-    public function parse(): MailMimeMessage
+    public function parse(): IMessage
     {
         if ($this->isEmpty()) {
             throw new RuntimeException('Cannot parse an empty message');

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -5,6 +5,7 @@ namespace DirectoryTree\ImapEngine;
 use Carbon\CarbonInterface;
 use Stringable;
 use ZBateson\MailMimeParser\Header\IHeader;
+use ZBateson\MailMimeParser\IMessage;
 use ZBateson\MailMimeParser\Message as MailMimeMessage;
 
 interface MessageInterface extends FlaggableInterface, Stringable
@@ -117,7 +118,7 @@ interface MessageInterface extends FlaggableInterface, Stringable
     /**
      * Parse the message into a MailMimeMessage instance.
      */
-    public function parse(): MailMimeMessage;
+    public function parse(): IMessage;
 
     /**
      * Determine if the message is the same as another message.

--- a/src/MessageParser.php
+++ b/src/MessageParser.php
@@ -2,6 +2,7 @@
 
 namespace DirectoryTree\ImapEngine;
 
+use ZBateson\MailMimeParser\IMessage;
 use ZBateson\MailMimeParser\MailMimeParser;
 use ZBateson\MailMimeParser\Message as MailMimeMessage;
 
@@ -15,7 +16,7 @@ class MessageParser
     /**
      * Parse the given message contents.
      */
-    public static function parse(string $contents): MailMimeMessage
+    public static function parse(string $contents): IMessage
     {
         return static::parser()->parse($contents, true);
     }

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -44,7 +44,7 @@ class MessageQuery implements MessageQueryInterface
     /**
      * Get the first message in the resulting collection.
      *
-     * @return Message|null
+     * @return MessageInterface|null
      */
     public function first(): ?MessageInterface
     {
@@ -58,7 +58,7 @@ class MessageQuery implements MessageQueryInterface
     /**
      * Get the first message in the resulting collection or throw an exception.
      *
-     * @return Message
+     * @return MessageInterface
      */
     public function firstOrFail(): MessageInterface
     {
@@ -82,7 +82,7 @@ class MessageQuery implements MessageQueryInterface
             $this->folder->path(), $message, Str::enums($flags),
         );
 
-        return $response // TAG4 OK [APPENDUID <uidvalidity> <uid>] APPEND completed.
+        return (int) $response // TAG4 OK [APPENDUID <uidvalidity> <uid>] APPEND completed.
             ->tokenAt(2) // [APPENDUID <uidvalidity> <uid>]
             ->tokenAt(2) // <uid>
             ->value;
@@ -169,7 +169,7 @@ class MessageQuery implements MessageQueryInterface
     /**
      * Find a message by the given identifier type or throw an exception.
      *
-     * @return Message
+     * @return MessageInterface
      */
     public function findOrFail(int $id, ImapFetchIdentifier $identifier = ImapFetchIdentifier::Uid): MessageInterface
     {
@@ -186,7 +186,7 @@ class MessageQuery implements MessageQueryInterface
     /**
      * Find a message by the given identifier type.
      *
-     * @return Message|null
+     * @return MessageInterface|null
      */
     public function find(int $id, ImapFetchIdentifier $identifier = ImapFetchIdentifier::Uid): ?MessageInterface
     {

--- a/src/MessageQueryInterface.php
+++ b/src/MessageQueryInterface.php
@@ -129,14 +129,14 @@ interface MessageQueryInterface
     /**
      * Get the first message in the resulting collection.
      *
-     * @return \DirectoryTree\ImapEngine\Message|null
+     * @return MessageInterface|null
      */
     public function first(): ?MessageInterface;
 
     /**
      * Get the first message in the resulting collection or throw an exception.
      *
-     * @return \DirectoryTree\ImapEngine\Message
+     * @return MessageInterface
      */
     public function firstOrFail(): MessageInterface;
 
@@ -168,14 +168,14 @@ interface MessageQueryInterface
     /**
      * Find a message by the given identifier type or throw an exception.
      *
-     * @return \DirectoryTree\ImapEngine\Message
+     * @return MessageInterface
      */
     public function findOrFail(int $id, ImapFetchIdentifier $identifier = ImapFetchIdentifier::Uid): MessageInterface;
 
     /**
      * Find a message by the given identifier type.
      *
-     * @return \DirectoryTree\ImapEngine\Message|null
+     * @return MessageInterface|null
      */
     public function find(int $id, ImapFetchIdentifier $identifier = ImapFetchIdentifier::Uid): ?MessageInterface;
 


### PR DESCRIPTION
Same as before. This time the branch is not locked :smile: 

Most of these changes are contradicting return types. PHP return type says MessageInterface vs. PHPDoc says Message. I switched everything around to the interface as it better aligns with the "user can override everything"-idea.

I changed the template tags of ResponseCollection around. I'm no expert in these, but bevore PHPStan had problems understanding the generic, with this change it works out-of-the box.