### PR TITLE
In-Reply-To is handled as an address, but should be handled the same as Message-ID

### DIFF
--- a/src/HasParsedMessage.php
+++ b/src/HasParsedMessage.php
@@ -80,11 +80,19 @@ trait HasParsedMessage
     }
 
     /**
-     * Get the IN-REPLY-TO address.
+     * Get the IN-REPLY-TO message identifier(s).
+     *
+     * @return string[]
      */
-    public function inReplyTo(): ?Address
+    public function inReplyTo(): array
     {
-        return head($this->addresses(HeaderConsts::IN_REPLY_TO)) ?: null;
+        $parts = $this->header(HeaderConsts::IN_REPLY_TO)?->getParts() ?? [];
+
+        $values = array_map(function (IHeaderPart $part) {
+            return $part->getValue();
+        }, $parts);
+
+        return array_values(array_filter($values));
     }
 
     /**

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -46,9 +46,11 @@ interface MessageInterface extends FlaggableInterface, Stringable
     public function replyTo(): ?Address;
 
     /**
-     * Get the 'In-Reply-To' address.
+     * Get the 'In-Reply-To' message identifier(s).
+     *
+     * @return string[]
      */
-    public function inReplyTo(): ?Address;
+    public function inReplyTo(): array;
 
     /**
      * Get the 'To' addresses.

--- a/tests/Unit/FileMessageTest.php
+++ b/tests/Unit/FileMessageTest.php
@@ -144,10 +144,10 @@ test('it recognizes when there are no attachments', function () {
     expect($message->attachments())->toBe([]);
 });
 
-test('it can parse other header fields like IN-REPLY-TO', function () {
+test('it can parse In-Reply-To header', function () {
     $contents = <<<'EOT'
     From: "John Doe" <john@example.com>
-    In-Reply-To: <some-other-message@server.example.com>, <another-message@server.example.com>
+    In-Reply-To: <some-other-message@server.example.com>
     Subject: In-Reply-To Check
     Date: Wed, 19 Feb 2025 12:34:56 -0500
     Content-Type: text/plain; charset="UTF-8"
@@ -157,9 +157,42 @@ test('it can parse other header fields like IN-REPLY-TO', function () {
 
     $message = new FileMessage($contents);
 
-    $address = $message->inReplyTo();
-    expect($address)->not->toBeNull();
-    expect($address->email())->toBe('some-other-message@server.example.com');
+    expect($message->inReplyTo())->toBe(['some-other-message@server.example.com']);
+});
+
+test('it can parse In-Reply-To header with multiple values', function () {
+    $contents = <<<'EOT'
+    From: "John Doe" <john@example.com>
+    In-Reply-To: <first-message@server.example.com> <second-message@server.example.com> <third-message@server.example.com>
+    Subject: In-Reply-To Check
+    Date: Wed, 19 Feb 2025 12:34:56 -0500
+    Content-Type: text/plain; charset="UTF-8"
+
+    Check the in-reply-to header
+    EOT;
+
+    $message = new FileMessage($contents);
+
+    expect($message->inReplyTo())->toBe([
+        'first-message@server.example.com',
+        'second-message@server.example.com',
+        'third-message@server.example.com',
+    ]);
+});
+
+test('it returns empty array when In-Reply-To header is missing', function () {
+    $contents = <<<'EOT'
+    From: "John Doe" <john@example.com>
+    Subject: No In-Reply-To
+    Date: Wed, 19 Feb 2025 12:34:56 -0500
+    Content-Type: text/plain; charset="UTF-8"
+
+    No in-reply-to header
+    EOT;
+
+    $message = new FileMessage($contents);
+
+    expect($message->inReplyTo())->toBe([]);
 });
 
 test('it can be cast to a string via __toString()', function () {


### PR DESCRIPTION
Closes #118 

This a breaking change, but it's also a bug, so I think it makes sense to patch it without a new major version.