### PR TITLE
Consider messages as equal only if their UID and folder is the same

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -105,8 +105,6 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     {
         return $message instanceof self
             && $this->uid === $message->uid
-            && $this->head === $message->head
-            && $this->body === $message->body
             && $this->folder->is($message->folder);
     }
 

--- a/tests/Unit/MessageTest.php
+++ b/tests/Unit/MessageTest.php
@@ -133,15 +133,15 @@ test('it can determine if two messages are the same', function () {
     // Same message
     expect($message1->is($message2))->toBeTrue();
 
+    // Different header
+    expect($message1->is($message5))->toBeTrue();
+
+    // Different body
+    expect($message1->is($message6))->toBeTrue();
+
     // Different UID
     expect($message1->is($message3))->toBeFalse();
 
     // Different folder
     expect($message1->is($message4))->toBeFalse();
-
-    // Different header
-    expect($message1->is($message5))->toBeFalse();
-
-    // Different body
-    expect($message1->is($message6))->toBeFalse();
 });


### PR DESCRIPTION
Closes #122 

Since `$folder->is(...)` already checks to ensure the connection is the same, we only need to check UID:

https://github.com/DirectoryTree/ImapEngine/blob/d8006ef7111fd115b143ed8bc611dcca8b445fe6/src/ComparesFolders.php#L9-L15