### PR TITLE
Fix: issue 132 - pathinfo(): Passing null to parameter #1 () of type …

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -81,7 +81,11 @@ class Attachment implements Arrayable, JsonSerializable
      */
     public function extension(): ?string
     {
-        if ($ext = pathinfo($this->filename ?? '', PATHINFO_EXTENSION)) {
+        if (! $this->filename) {
+            return null;
+        }
+
+        if ($ext = pathinfo($this->filename, PATHINFO_EXTENSION)) {
             return $ext;
         }
 


### PR DESCRIPTION
Handle null attachment filenames when calling extension(). Fixes #132 