### PR TITLE
Add polling support for new messages in folders

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -151,7 +151,8 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
                 try {
                     $callback($message);
                 } catch (Exception) {
-                    // Something happened. We will attempt reconnecting.
+                    // Something unexpected happened. We will attempt
+                    // reconnecting and continue polling for messages.
                     $this->mailbox->reconnect();
                 }
             },

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -140,6 +140,33 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
     /**
      * {@inheritDoc}
      */
+    public function poll(int $frequency, callable $callback, ?callable $query = null): void
+    {
+        // The message query to use when fetching messages.
+        $query ??= fn (MessageQuery $query) => $query;
+
+        (new Poll(clone $this->mailbox, $this->path, $frequency))->start(
+            function (MessageInterface $message) use ($callback, $query) {
+                if (! $this->mailbox->connected()) {
+                    $this->mailbox->connect();
+                }
+
+                try {
+                    // Apply the query to the message if needed.
+                    $query($this->messages());
+
+                    $callback($message);
+                } catch (Exception) {
+                    // Something happened. We will attempt reconnecting.
+                    $this->mailbox->reconnect();
+                }
+            }
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function move(string $newPath): void
     {
         $this->mailbox->connection()->rename($this->path, $newPath);

--- a/src/FolderInterface.php
+++ b/src/FolderInterface.php
@@ -47,9 +47,9 @@ interface FolderInterface
     public function idle(callable $callback, ?callable $query = null, callable|int $timeout = 300): void;
 
     /**
-     * Poll for new messages at a given frequency.
+     * Begin polling for new messages at a given frequency.
      */
-    public function poll(int $frequency, callable $callback, ?callable $query = null): void;
+    public function poll(callable $callback, ?callable $query = null, callable|int $frequency = 60): void;
 
     /**
      * Move or rename the current folder.

--- a/src/FolderInterface.php
+++ b/src/FolderInterface.php
@@ -42,12 +42,12 @@ interface FolderInterface
     public function messages(): MessageQueryInterface;
 
     /**
-     * Begin idling on the current folder.
+     * Begin idling on the current folder for the given timeout in seconds.
      */
     public function idle(callable $callback, ?callable $query = null, callable|int $timeout = 300): void;
 
     /**
-     * Begin polling for new messages at a given frequency.
+     * Begin polling for new messages at the given frequency in seconds.
      */
     public function poll(callable $callback, ?callable $query = null, callable|int $frequency = 60): void;
 

--- a/src/FolderInterface.php
+++ b/src/FolderInterface.php
@@ -47,6 +47,11 @@ interface FolderInterface
     public function idle(callable $callback, ?callable $query = null, callable|int $timeout = 300): void;
 
     /**
+     * Poll for new messages at a given frequency.
+     */
+    public function poll(int $frequency, callable $callback, ?callable $query = null): void;
+
+    /**
      * Move or rename the current folder.
      */
     public function move(string $newPath): void;

--- a/src/Poll.php
+++ b/src/Poll.php
@@ -55,6 +55,8 @@ class Poll
     {
         $folder = $this->folder();
 
+        // If we don't have a last seen UID, we will fetch
+        // the last one in the folder as a starting point.
         if (! $this->lastSeenUid) {
             $this->lastSeenUid = $folder->messages()
                 ->first()

--- a/src/Poll.php
+++ b/src/Poll.php
@@ -66,6 +66,13 @@ class Poll
         $query($folder->messages())
             ->uid($this->lastSeenUid + 1, INF)
             ->each(function (MessageInterface $message) use ($callback) {
+                // Avoid processing the same message twice on subsequent polls.
+                // Some IMAP servers will always return the last seen UID in
+                // the search results regardless of UID search scope.
+                if ($this->lastSeenUid === $message->uid()) {
+                    return;
+                }
+
                 $callback($message);
 
                 $this->lastSeenUid = $message->uid();

--- a/src/Poll.php
+++ b/src/Poll.php
@@ -68,7 +68,7 @@ class Poll
             ->each(function (MessageInterface $message) use ($callback) {
                 // Avoid processing the same message twice on subsequent polls.
                 // Some IMAP servers will always return the last seen UID in
-                // the search results regardless of UID search scope.
+                // the search results regardless of given UID search range.
                 if ($this->lastSeenUid === $message->uid()) {
                     return;
                 }

--- a/src/Poll.php
+++ b/src/Poll.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace DirectoryTree\ImapEngine;
+
+use Closure;
+use DirectoryTree\ImapEngine\Exceptions\Exception;
+use DirectoryTree\ImapEngine\Exceptions\ImapConnectionClosedException;
+
+class Poll
+{
+    /**
+     * The last seen message UID.
+     */
+    protected ?int $lastSeenUid = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        protected Mailbox $mailbox,
+        protected string $folder,
+        protected Closure|int $frequency,
+    ) {}
+
+    /**
+     * Destructor.
+     */
+    public function __destruct()
+    {
+        $this->disconnect();
+    }
+
+    /**
+     * Poll for new messages at a given frequency.
+     */
+    public function start(callable $callback): void
+    {
+        $this->connect();
+
+        while ($frequency = $this->getNextFrequency()) {
+            try {
+                $this->check($callback);
+            } catch (ImapConnectionClosedException) {
+                $this->reconnect();
+            }
+
+            sleep($frequency);
+        }
+    }
+
+    /**
+     * Check for new messages since the last seen UID.
+     */
+    protected function check(callable $callback): void
+    {
+        $folder = $this->folder();
+
+        $query = $folder->messages();
+
+        // If we have a last seen UID, search for messages after it.
+        if ($this->lastSeenUid !== null) {
+            $query->uid($this->lastSeenUid + 1, INF);
+        }
+
+        $messages = $query->get();
+
+        foreach ($messages as $message) {
+            $callback($message);
+
+            $this->lastSeenUid = $message->uid();
+        }
+    }
+
+    /**
+     * Get the folder to poll.
+     */
+    protected function folder(): FolderInterface
+    {
+        return $this->mailbox->folders()->findOrFail($this->folder);
+    }
+
+    /**
+     * Reconnect the client and restart the poll session.
+     */
+    protected function reconnect(): void
+    {
+        $this->mailbox->disconnect();
+
+        $this->connect();
+    }
+
+    /**
+     * Connect the client and select the folder to poll.
+     */
+    protected function connect(): void
+    {
+        $this->mailbox->connect();
+
+        $this->mailbox->select($this->folder(), true);
+    }
+
+    /**
+     * Disconnect the client.
+     */
+    protected function disconnect(): void
+    {
+        try {
+            $this->mailbox->disconnect();
+        } catch (Exception) {
+            // Do nothing.
+        }
+    }
+
+    /**
+     * Get the next frequency in seconds.
+     */
+    protected function getNextFrequency(): int|false
+    {
+        if (is_numeric($seconds = value($this->frequency))) {
+            return abs((int) $seconds);
+        }
+
+        return false;
+    }
+}

--- a/src/Testing/FakeFolder.php
+++ b/src/Testing/FakeFolder.php
@@ -99,7 +99,7 @@ class FakeFolder implements FolderInterface
     /**
      * {@inheritDoc}
      */
-    public function poll(int $frequency, callable $callback, ?callable $query = null): void
+    public function poll(callable $callback, ?callable $query = null, callable|int $frequency = 60): void
     {
         foreach ($this->messages as $message) {
             $callback($message);

--- a/src/Testing/FakeFolder.php
+++ b/src/Testing/FakeFolder.php
@@ -99,6 +99,16 @@ class FakeFolder implements FolderInterface
     /**
      * {@inheritDoc}
      */
+    public function poll(int $frequency, callable $callback, ?callable $query = null): void
+    {
+        foreach ($this->messages as $message) {
+            $callback($message);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function move(string $newPath): void
     {
         // Do nothing.


### PR DESCRIPTION
This PR introduces a new polling feature for detecting new messages in mail folders, alongside necessary interface and test updates. The main change is the addition of a `poll` method, which regularly checks for new messages at a specified frequency and invokes a callback for each new message. The supporting infrastructure for polling is encapsulated in a new `Poll` class.

This allows developers who cannot use IMAP IDLE to use long polling in its place using the same kind of structure as the existing `idle()` method.