### PR TITLE
Move `Atom::is()` and `Atom::isNot()` to base `Token` class

### DIFF
--- a/src/Connection/Tokens/Atom.php
+++ b/src/Connection/Tokens/Atom.php
@@ -5,21 +5,4 @@ namespace DirectoryTree\ImapEngine\Connection\Tokens;
 /**
  * @see https://datatracker.ietf.org/doc/html/rfc9051#name-atom
  */
-class Atom extends Token
-{
-    /**
-     * Determine if the token is the given value.
-     */
-    public function is(string $value): bool
-    {
-        return $this->value === $value;
-    }
-
-    /**
-     * Determine if the token is not the given value.
-     */
-    public function isNot(string $value): bool
-    {
-        return ! $this->is($value);
-    }
-}
+class Atom extends Token {}

--- a/src/Connection/Tokens/Token.php
+++ b/src/Connection/Tokens/Token.php
@@ -14,6 +14,22 @@ abstract class Token implements Stringable
     ) {}
 
     /**
+     * Determine if the token is the given value.
+     */
+    public function is(string $value): bool
+    {
+        return $this->value === $value;
+    }
+
+    /**
+     * Determine if the token is not the given value.
+     */
+    public function isNot(string $value): bool
+    {
+        return ! $this->is($value);
+    }
+
+    /**
      * Get the token's value.
      */
     public function __toString(): string


### PR DESCRIPTION
Closes #136 