### PR TITLE
Add message larger/smaller query support

### DIFF
--- a/src/Connection/ImapQueryBuilder.php
+++ b/src/Connection/ImapQueryBuilder.php
@@ -236,6 +236,22 @@ class ImapQueryBuilder
     }
 
     /**
+     * Add a where "LARGER" clause to the query.
+     */
+    public function larger(int $bytes): static
+    {
+        return $this->where(ImapSearchKey::Larger, new RawQueryValue($bytes));
+    }
+
+    /**
+     * Add a where "SMALLER" clause to the query.
+     */
+    public function smaller(int $bytes): static
+    {
+        return $this->where(ImapSearchKey::Smaller, new RawQueryValue($bytes));
+    }
+
+    /**
      * Add a "where" condition.
      */
     public function where(mixed $column, mixed $value = null): static

--- a/src/Enums/ImapSearchKey.php
+++ b/src/Enums/ImapSearchKey.php
@@ -22,10 +22,12 @@ enum ImapSearchKey: string
     case Unseen = 'UNSEEN';
     case Before = 'BEFORE';
     case Header = 'HEADER';
+    case Larger = 'LARGER';
     case Deleted = 'DELETED';
     case Flagged = 'FLAGGED';
     case Keyword = 'KEYWORD';
     case Subject = 'SUBJECT';
+    case Smaller = 'SMALLER';
     case Answered = 'ANSWERED';
     case Undeleted = 'UNDELETED';
     case Unflagged = 'UNFLAGGED';

--- a/tests/Unit/Connection/ImapQueryBuilderTest.php
+++ b/tests/Unit/Connection/ImapQueryBuilderTest.php
@@ -284,3 +284,19 @@ test('compiles UID range with single value array', function () {
 
     expect($builder->toImap())->toBe('UID 2');
 });
+
+test('compiles LARGER condition without quotes', function () {
+    expect((new ImapQueryBuilder)->larger(5242880)->toImap())->toBe('LARGER 5242880');
+});
+
+test('compiles SMALLER condition without quotes', function () {
+    expect((new ImapQueryBuilder)->smaller(10240)->toImap())->toBe('SMALLER 10240');
+});
+
+test('compiles LARGER and SMALLER conditions together', function () {
+    $builder = new ImapQueryBuilder;
+
+    $builder->larger(1024)->smaller(1048576);
+
+    expect($builder->toImap())->toBe('LARGER 1024 SMALLER 1048576');
+});


### PR DESCRIPTION
This PR adds support for the IMAP `LARGER` and `SMALLER` search criteria to the query builder, allowing users to filter messages by size.