### PR TITLE
Add bulk query operations

### DIFF
--- a/src/MessageQueryInterface.php
+++ b/src/MessageQueryInterface.php
@@ -2,6 +2,7 @@
 
 namespace DirectoryTree\ImapEngine;
 
+use BackedEnum;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
@@ -205,4 +206,61 @@ interface MessageQueryInterface
      * Destroy the given messages.
      */
     public function destroy(array|int $uids, bool $expunge = false): void;
+
+    /**
+     * Add or remove a flag from all messages matching the current query.
+     *
+     * @param  string  $operation  '+'|'-'
+     * @return int The number of messages affected.
+     */
+    public function flag(BackedEnum|string $flag, string $operation, bool $expunge = false): int;
+
+    /**
+     * Mark all messages matching the current query as read.
+     *
+     * @return int The number of messages affected.
+     */
+    public function markRead(): int;
+
+    /**
+     * Mark all messages matching the current query as unread.
+     *
+     * @return int The number of messages affected.
+     */
+    public function markUnread(): int;
+
+    /**
+     * Mark all messages matching the current query as flagged.
+     *
+     * @return int The number of messages affected.
+     */
+    public function markFlagged(): int;
+
+    /**
+     * Unmark all messages matching the current query as flagged.
+     *
+     * @return int The number of messages affected.
+     */
+    public function unmarkFlagged(): int;
+
+    /**
+     * Delete all messages matching the current query.
+     *
+     * @return int The number of messages affected.
+     */
+    public function delete(bool $expunge = false): int;
+
+    /**
+     * Move all messages matching the current query to the given folder.
+     *
+     * @return int The number of messages affected.
+     */
+    public function move(string $folder, bool $expunge = false): int;
+
+    /**
+     * Copy all messages matching the current query to the given folder.
+     *
+     * @return int The number of messages affected.
+     */
+    public function copy(string $folder): int;
 }

--- a/src/Testing/FakeMessageQuery.php
+++ b/src/Testing/FakeMessageQuery.php
@@ -2,6 +2,7 @@
 
 namespace DirectoryTree\ImapEngine\Testing;
 
+use BackedEnum;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
@@ -153,5 +154,73 @@ class FakeMessageQuery implements MessageQueryInterface
         $this->folder->setMessages(
             $messages->values()->all()
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function flag(BackedEnum|string $flag, string $operation, bool $expunge = false): int
+    {
+        return count($this->folder->getMessages());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function markRead(): int
+    {
+        return count($this->folder->getMessages());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function markUnread(): int
+    {
+        return count($this->folder->getMessages());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function markFlagged(): int
+    {
+        return count($this->folder->getMessages());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unmarkFlagged(): int
+    {
+        return count($this->folder->getMessages());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete(bool $expunge = false): int
+    {
+        $count = count($this->folder->getMessages());
+
+        $this->folder->setMessages([]);
+
+        return $count;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function move(string $folder, bool $expunge = false): int
+    {
+        return count($this->folder->getMessages());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function copy(string $folder): int
+    {
+        return count($this->folder->getMessages());
     }
 }


### PR DESCRIPTION
This PR adds the ability to perform bulk message operations on a folder. For example:

```php
// Single message operations
$message->markRead();
$message->move('Archive');
$message->delete();

// Batch message operations
$folder->messages()->unseen()->markRead();
$folder->messages()->before('2023-01-01')->move('Archive');
$folder->messages()->from('spam@example.com')->delete();
```