### PR TITLE
Implement IMAP SORT

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ ubuntu-latest ]
-                php: [ 8.4, 8.3, 8.2, 8.1 ]
+                php: [ 8.5, 8.4, 8.3, 8.2 ]
                 dependency-version: [ prefer-stable ]
 
         name: ${{ matrix.os }} - P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ ubuntu-latest ]
-                php: [ 8.4, 8.3, 8.2, 8.1 ]
+                php: [ 8.5, 8.4, 8.3, 8.2 ]
                 dependency-version: [ prefer-stable ]
 
         name: ${{ matrix.os }} - P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "spatie/ray": "^1.0",
-        "pestphp/pest": "^2.0|^3.0"
+        "pestphp/pest": "^2.0|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -6,6 +6,7 @@ use DirectoryTree\ImapEngine\Collections\ResponseCollection;
 use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
+use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use Generator;
 
 interface ConnectionInterface
@@ -110,6 +111,15 @@ interface ConnectionInterface
      * @see https://datatracker.ietf.org/doc/html/rfc9051#name-search-command
      */
     public function search(array $params): UntaggedResponse;
+
+    /**
+     * Send a "SORT" command.
+     *
+     * Execute a sort request using RFC 5256.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc5256
+     */
+    public function sort(ImapSortKey $key, string $direction, array $params): UntaggedResponse;
 
     /**
      * Send a "FETCH" command.

--- a/src/Connection/ImapConnection.php
+++ b/src/Connection/ImapConnection.php
@@ -14,6 +14,7 @@ use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
 use DirectoryTree\ImapEngine\Connection\Streams\StreamInterface;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
+use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\Exceptions\ImapCommandException;
 use DirectoryTree\ImapEngine\Exceptions\ImapConnectionClosedException;
 use DirectoryTree\ImapEngine\Exceptions\ImapConnectionFailedException;
@@ -494,6 +495,22 @@ class ImapConnection implements ConnectionInterface
 
         return $this->result->responses()->untagged()->firstOrFail(
             fn (UntaggedResponse $response) => $response->type()->is('SEARCH')
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sort(ImapSortKey $key, string $direction, array $params): UntaggedResponse
+    {
+        $sortCriteria = $direction === 'desc' ? "REVERSE {$key->value}" : $key->value;
+
+        $this->send('UID SORT', ["({$sortCriteria})", 'UTF-8', ...$params], tag: $tag);
+
+        $this->assertTaggedResponse($tag);
+
+        return $this->result->responses()->untagged()->firstOrFail(
+            fn (UntaggedResponse $response) => $response->type()->is('SORT')
         );
     }
 

--- a/src/Enums/ImapSortKey.php
+++ b/src/Enums/ImapSortKey.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DirectoryTree\ImapEngine\Enums;
+
+enum ImapSortKey: string
+{
+    case Cc = 'CC';
+    case To = 'TO';
+    case Date = 'DATE';
+    case From = 'FROM';
+    case Size = 'SIZE';
+    case Arrival = 'ARRIVAL';
+    case Subject = 'SUBJECT';
+}

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -48,12 +48,20 @@ class MessageQuery implements MessageQueryInterface
     /**
      * Set the server-side sort criteria using RFC 5256 SORT extension.
      */
-    public function sortBy(string|ImapSortKey $key, string $direction = 'asc'): static
+    public function sortBy(ImapSortKey|string $key, string $direction = 'asc'): static
     {
         $this->sortKey = is_string($key) ? ImapSortKey::from(strtoupper($key)) : $key;
         $this->sortDirection = strtolower($direction);
 
         return $this;
+    }
+
+    /**
+     * Set the server-side sort criteria using RFC 5256 SORT extension (in descending order).
+     */
+    public function sortByDesc(ImapSortKey|string $key): static
+    {
+        return $this->sortBy($key, 'desc');
     }
 
     /**

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -12,6 +12,7 @@ use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
+use DirectoryTree\ImapEngine\Exceptions\ImapCapabilityException;
 use DirectoryTree\ImapEngine\Exceptions\ImapCommandException;
 use DirectoryTree\ImapEngine\Exceptions\RuntimeException;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
@@ -451,6 +452,12 @@ class MessageQuery implements MessageQueryInterface
      */
     protected function sort(): Collection
     {
+        if (! in_array('SORT', $this->folder->mailbox()->capabilities())) {
+            throw new ImapCapabilityException(
+                'Unable to sort messages. IMAP server does not support SORT capability.'
+            );
+        }
+
         if ($this->query->isEmpty()) {
             $this->query->all();
         }

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -355,10 +355,15 @@ class MessageQuery implements MessageQueryInterface
      */
     protected function fetch(Collection $messages): array
     {
-        $messages = match ($this->fetchOrder) {
-            'asc' => $messages->sort(SORT_NUMERIC),
-            'desc' => $messages->sortDesc(SORT_NUMERIC),
-        };
+        // Only apply client-side sorting when not using server-side sorting.
+        // When sortKey is set, the IMAP SORT command already returns UIDs
+        // in the correct order, so we should preserve that order.
+        if (! $this->sortKey) {
+            $messages = match ($this->fetchOrder) {
+                'asc' => $messages->sort(SORT_NUMERIC),
+                'desc' => $messages->sortDesc(SORT_NUMERIC),
+            };
+        }
 
         $uids = $messages->forPage($this->page, $this->limit)->values();
 

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -12,7 +12,6 @@ use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
-use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\Exceptions\ImapCommandException;
 use DirectoryTree\ImapEngine\Exceptions\RuntimeException;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
@@ -28,41 +27,12 @@ class MessageQuery implements MessageQueryInterface
     use QueriesMessages;
 
     /**
-     * The sort key to use for server-side sorting.
-     */
-    protected ?ImapSortKey $sortKey = null;
-
-    /**
-     * The sort direction (asc or desc).
-     */
-    protected string $sortDirection = 'asc';
-
-    /**
      * Constructor.
      */
     public function __construct(
         protected FolderInterface $folder,
         protected ImapQueryBuilder $query,
     ) {}
-
-    /**
-     * Set the server-side sort criteria using RFC 5256 SORT extension.
-     */
-    public function sortBy(ImapSortKey|string $key, string $direction = 'asc'): static
-    {
-        $this->sortKey = is_string($key) ? ImapSortKey::from(strtoupper($key)) : $key;
-        $this->sortDirection = strtolower($direction);
-
-        return $this;
-    }
-
-    /**
-     * Set the server-side sort criteria using RFC 5256 SORT extension (in descending order).
-     */
-    public function sortByDesc(ImapSortKey|string $key): static
-    {
-        return $this->sortBy($key, 'desc');
-    }
 
     /**
      * Count all available messages matching the current search criteria.

--- a/src/MessageQueryInterface.php
+++ b/src/MessageQueryInterface.php
@@ -5,6 +5,7 @@ namespace DirectoryTree\ImapEngine;
 use BackedEnum;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
+use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
 
 /**
@@ -151,6 +152,36 @@ interface MessageQueryInterface
      * Set the fetch order to show newest messages first (descending).
      */
     public function newest(): MessageQueryInterface;
+
+    /**
+     * Set the sort key for server-side sorting (RFC 5256).
+     */
+    public function setSortKey(ImapSortKey|string|null $key): MessageQueryInterface;
+
+    /**
+     * Get the sort key for server-side sorting.
+     */
+    public function getSortKey(): ?ImapSortKey;
+
+    /**
+     * Set the sort direction for server-side sorting.
+     */
+    public function setSortDirection(string $direction): MessageQueryInterface;
+
+    /**
+     * Get the sort direction for server-side sorting.
+     */
+    public function getSortDirection(): string;
+
+    /**
+     * Sort messages by a field using server-side sorting (RFC 5256).
+     */
+    public function sortBy(ImapSortKey|string $key, string $direction = 'asc'): MessageQueryInterface;
+
+    /**
+     * Sort messages by a field in descending order using server-side sorting.
+     */
+    public function sortByDesc(ImapSortKey|string $key): MessageQueryInterface;
 
     /**
      * Count all available messages matching the current search criteria.

--- a/src/QueriesMessages.php
+++ b/src/QueriesMessages.php
@@ -392,7 +392,7 @@ trait QueriesMessages
     public function setSortKey(ImapSortKey|string|null $key): MessageQueryInterface
     {
         if (is_string($key)) {
-            $key = ImapSortKey::tryFrom(strtoupper($key));
+            $key = ImapSortKey::from(strtoupper($key));
         }
 
         $this->sortKey = $key;

--- a/src/Testing/FakeMessageQuery.php
+++ b/src/Testing/FakeMessageQuery.php
@@ -6,7 +6,6 @@ use BackedEnum;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
-use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\MessageInterface;
 use DirectoryTree\ImapEngine\MessageQueryInterface;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
@@ -223,13 +222,5 @@ class FakeMessageQuery implements MessageQueryInterface
     public function copy(string $folder): int
     {
         return count($this->folder->getMessages());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function sortBy(ImapSortKey|string $key, string $direction = 'asc'): static
-    {
-        return $this;
     }
 }

--- a/src/Testing/FakeMessageQuery.php
+++ b/src/Testing/FakeMessageQuery.php
@@ -223,4 +223,12 @@ class FakeMessageQuery implements MessageQueryInterface
     {
         return count($this->folder->getMessages());
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sortBy(string|\DirectoryTree\ImapEngine\Enums\ImapSortKey $key, string $direction = 'asc'): static
+    {
+        return $this;
+    }
 }

--- a/src/Testing/FakeMessageQuery.php
+++ b/src/Testing/FakeMessageQuery.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
+use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\MessageInterface;
 use DirectoryTree\ImapEngine\MessageQueryInterface;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
@@ -227,7 +228,7 @@ class FakeMessageQuery implements MessageQueryInterface
     /**
      * {@inheritDoc}
      */
-    public function sortBy(string|\DirectoryTree\ImapEngine\Enums\ImapSortKey $key, string $direction = 'asc'): static
+    public function sortBy(ImapSortKey|string $key, string $direction = 'asc'): static
     {
         return $this;
     }

--- a/tests/Integration/MessagesTest.php
+++ b/tests/Integration/MessagesTest.php
@@ -453,3 +453,31 @@ test('querying for unseen messages', function () {
 
     expect($folder->messages()->unseen()->count())->toBe(0);
 });
+
+test('sort by subject', function () {
+    $folder = folder();
+
+    $uid1 = $folder->messages()->append(
+        new DraftMessage(
+            from: 'foo@email.com',
+            subject: 'AAA First alphabetically',
+            text: 'hello world',
+        ),
+    );
+
+    $uid2 = $folder->messages()->append(
+        new DraftMessage(
+            from: 'foo@email.com',
+            subject: 'ZZZ Last alphabetically',
+            text: 'hello world',
+        ),
+    );
+
+    // Ascending order: AAA should come before ZZZ
+    $messagesAsc = $folder->messages()->sortBy('subject', 'asc')->get();
+    expect($messagesAsc->map(fn (Message $message) => $message->uid())->all())->toEqual([$uid1, $uid2]);
+
+    // Descending order: ZZZ should come before AAA
+    $messagesDesc = $folder->messages()->sortBy('subject', 'desc')->get();
+    expect($messagesDesc->map(fn (Message $message) => $message->uid())->all())->toEqual([$uid2, $uid1]);
+});

--- a/tests/Unit/MessageQueryTest.php
+++ b/tests/Unit/MessageQueryTest.php
@@ -4,6 +4,7 @@ use DirectoryTree\ImapEngine\Connection\ImapConnection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
+use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\Folder;
 use DirectoryTree\ImapEngine\Mailbox;
 use DirectoryTree\ImapEngine\MessageQuery;
@@ -475,4 +476,80 @@ test('copy returns zero when no messages match', function () {
     $count = query($mailbox)->copy('Backup');
 
     expect($count)->toBe(0);
+});
+
+test('sortBy sends correct sort command with ascending order', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* SORT 3 1 2',
+        'TAG2 OK SORT completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    query($mailbox)->sortBy('date')->get();
+
+    $stream->assertWritten('TAG2 UID SORT (DATE) UTF-8 ALL');
+});
+
+test('sortBy sends correct sort command with descending order', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* SORT 2 1 3',
+        'TAG2 OK SORT completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    query($mailbox)->sortBy('date', 'desc')->get();
+
+    $stream->assertWritten('TAG2 UID SORT (REVERSE DATE) UTF-8 ALL');
+});
+
+test('sortBy works with ImapSortKey enum', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* SORT 1 2 3',
+        'TAG2 OK SORT completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    query($mailbox)->sortBy(ImapSortKey::Subject)->get();
+
+    $stream->assertWritten('TAG2 UID SORT (SUBJECT) UTF-8 ALL');
+});
+
+test('sortBy combined with search criteria', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* SORT 5 3',
+        'TAG2 OK SORT completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    query($mailbox)->unseen()->sortBy('arrival', 'desc')->get();
+
+    $stream->assertWritten('TAG2 UID SORT (REVERSE ARRIVAL) UTF-8 UNSEEN');
 });

--- a/tests/Unit/MessageQueryTest.php
+++ b/tests/Unit/MessageQueryTest.php
@@ -479,6 +479,10 @@ test('copy returns zero when no messages match', function () {
     expect($count)->toBe(0);
 });
 
+test('sortBy fails with incorrect string key', function () {
+    query()->sortBy('invalid');
+})->throws(ValueError::class);
+
 test('sortBy sends correct sort command with ascending order', function () {
     $stream = new FakeStream;
     $stream->open();


### PR DESCRIPTION
Closes #80

This PR adds support for server-side message sorting using the IMAP RFC 5256 SORT extension. The main changes include introducing an `ImapSortKey` enum, updating `MessageQuery` to allow specifying sort criteria and direction, and implementing the new `sort` command in the connection layer.