### PR TITLE
Add unkeyword support

### DIFF
--- a/src/Connection/ImapQueryBuilder.php
+++ b/src/Connection/ImapQueryBuilder.php
@@ -174,6 +174,14 @@ class ImapQueryBuilder
     }
 
     /**
+     * Add a where "UNKEYWORD" clause to the query.
+     */
+    public function unkeyword(string $value): static
+    {
+        return $this->where(ImapSearchKey::Unkeyword, $value);
+    }
+
+    /**
      * Add a where "ON" clause to the query.
      */
     public function on(mixed $date): static

--- a/src/Enums/ImapSearchKey.php
+++ b/src/Enums/ImapSearchKey.php
@@ -26,6 +26,7 @@ enum ImapSearchKey: string
     case Deleted = 'DELETED';
     case Flagged = 'FLAGGED';
     case Keyword = 'KEYWORD';
+    case Unkeyword = 'UNKEYWORD';
     case Subject = 'SUBJECT';
     case Smaller = 'SMALLER';
     case Answered = 'ANSWERED';

--- a/tests/Unit/Connection/ImapQueryBuilderTest.php
+++ b/tests/Unit/Connection/ImapQueryBuilderTest.php
@@ -300,3 +300,11 @@ test('compiles LARGER and SMALLER conditions together', function () {
 
     expect($builder->toImap())->toBe('LARGER 1024 SMALLER 1048576');
 });
+
+test('compiles KEYWORD condition', function () {
+    expect((new ImapQueryBuilder)->keyword('important')->toImap())->toBe('KEYWORD "important"');
+});
+
+test('compiles UNKEYWORD condition', function () {
+    expect((new ImapQueryBuilder)->unkeyword('important')->toImap())->toBe('UNKEYWORD "important"');
+});


### PR DESCRIPTION
This PR adds support for the "UNKEYWORD" IMAP search condition to the query builder, alongside the existing "KEYWORD" condition.
