### PR TITLE
Add ability to lazy load message contents (html, text, attachments, and bodyStructure)

### DIFF
--- a/src/HasParsedMessage.php
+++ b/src/HasParsedMessage.php
@@ -21,7 +21,7 @@ trait HasParsedMessage
     /**
      * The parsed message.
      */
-    protected ?IMessage $parsed = null;
+    protected ?IMessage $message = null;
 
     /**
      * Get the message date and time.
@@ -243,7 +243,7 @@ trait HasParsedMessage
             throw new RuntimeException('Cannot parse an empty message');
         }
 
-        return $this->parsed ??= MessageParser::parse((string) $this);
+        return $this->message ??= MessageParser::parse((string) $this);
     }
 
     /**

--- a/src/Message.php
+++ b/src/Message.php
@@ -12,7 +12,11 @@ use JsonSerializable;
 
 class Message implements Arrayable, JsonSerializable, MessageInterface
 {
-    use HasFlags, HasParsedMessage;
+    use HasFlags, HasParsedMessage {
+        text as protected getParsedText;
+        html as protected getParsedHtml;
+        attachments as protected getParsedAttachments;
+    }
 
     /**
      * The parsed body structure.
@@ -106,12 +110,17 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     }
 
     /**
-     * Get the message's body structure.
+     * Get the message's body structure, fetching it from the server if necessary.
      */
     public function bodyStructure(): ?BodyStructureCollection
     {
         if ($this->bodyStructure) {
             return $this->bodyStructure;
+        }
+
+        // If we don't have body structure data, lazy load it from the server.
+        if (! $this->bodyStructureData) {
+            $this->bodyStructureData = $this->fetchBodyStructureData();
         }
 
         if (! $tokens = $this->bodyStructureData?->tokens()) {
@@ -219,6 +228,67 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     }
 
     /**
+     * Get the message's text content.
+     */
+    public function text(bool $lazy = false): ?string
+    {
+        if ($lazy && ! $this->hasBody()) {
+            if ($part = $this->bodyStructure()?->text()) {
+                return Support\BodyPartDecoder::text($part, $this->bodyPart($part->partNumber()));
+            }
+        }
+
+        return $this->getParsedText();
+    }
+
+    /**
+     * Get the message's HTML content.
+     */
+    public function html(bool $lazy = false): ?string
+    {
+        if ($lazy && ! $this->hasBody()) {
+            if ($part = $this->bodyStructure()?->html()) {
+                return Support\BodyPartDecoder::text($part, $this->bodyPart($part->partNumber()));
+            }
+        }
+
+        return $this->getParsedHtml();
+    }
+
+    /**
+     * Get the message's attachments.
+     *
+     * @return Attachment[]
+     */
+    public function attachments(bool $lazy = false): array
+    {
+        if ($lazy && ! $this->hasBody()) {
+            return $this->getLazyAttachments();
+        }
+
+        return $this->getParsedAttachments();
+    }
+
+    /**
+     * Get attachments using lazy loading from body structure.
+     *
+     * @return Attachment[]
+     */
+    protected function getLazyAttachments(): array
+    {
+        return array_map(
+            fn (BodyStructurePart $part) => new Attachment(
+                $part->filename(),
+                $part->id(),
+                $part->contentType(),
+                $part->disposition()?->type(),
+                new Support\LazyBodyPartStream($this, $part),
+            ),
+            $this->bodyStructure()?->attachments() ?? []
+        );
+    }
+
+    /**
      * Fetch a specific body part by part number.
      */
     public function bodyPart(string $partNumber, bool $peek = true): ?string
@@ -295,5 +365,28 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     public function isEmpty(): bool
     {
         return ! $this->hasHead() && ! $this->hasBody();
+    }
+
+    /**
+     * Fetch the body structure data from the server.
+     */
+    protected function fetchBodyStructureData(): ?ListData
+    {
+        $response = $this->folder
+            ->mailbox()
+            ->connection()
+            ->bodyStructure($this->uid);
+
+        if ($response->isEmpty()) {
+            return null;
+        }
+
+        $data = $response->first()->tokenAt(3);
+
+        if (! $data instanceof ListData) {
+            return null;
+        }
+
+        return $data->lookup('BODYSTRUCTURE');
     }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -110,16 +110,15 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     }
 
     /**
-     * Get the message's body structure, fetching it from the server if necessary.
+     * Get the message's body structure.
      */
-    public function bodyStructure(): ?BodyStructureCollection
+    public function bodyStructure(bool $lazy = false): ?BodyStructureCollection
     {
         if ($this->bodyStructure) {
             return $this->bodyStructure;
         }
 
-        // If we don't have body structure data, lazy load it from the server.
-        if (! $this->bodyStructureData) {
+        if (! $this->bodyStructureData && $lazy) {
             $this->bodyStructureData = $this->fetchBodyStructureData();
         }
 
@@ -233,7 +232,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     public function text(bool $lazy = false): ?string
     {
         if ($lazy && ! $this->hasBody()) {
-            if ($part = $this->bodyStructure()?->text()) {
+            if ($part = $this->bodyStructure(lazy: true)?->text()) {
                 return Support\BodyPartDecoder::text($part, $this->bodyPart($part->partNumber()));
             }
         }
@@ -247,7 +246,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     public function html(bool $lazy = false): ?string
     {
         if ($lazy && ! $this->hasBody()) {
-            if ($part = $this->bodyStructure()?->html()) {
+            if ($part = $this->bodyStructure(lazy: true)?->html()) {
                 return Support\BodyPartDecoder::text($part, $this->bodyPart($part->partNumber()));
             }
         }
@@ -284,7 +283,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
                 $part->disposition()?->type()?->value,
                 new Support\LazyBodyPartStream($this, $part),
             ),
-            $this->bodyStructure()?->attachments() ?? []
+            $this->bodyStructure(lazy: true)?->attachments() ?? []
         );
     }
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -281,7 +281,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
                 $part->filename(),
                 $part->id(),
                 $part->contentType(),
-                $part->disposition()?->type(),
+                $part->disposition()?->type()?->value,
                 new Support\LazyBodyPartStream($this, $part),
             ),
             $this->bodyStructure()?->attachments() ?? []

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
 
 /**
- * @mixin \DirectoryTree\ImapEngine\Connection\ImapQueryBuilder
+ * @mixin ImapQueryBuilder
  */
 class MessageQuery implements MessageQueryInterface
 {

--- a/src/MessageQueryInterface.php
+++ b/src/MessageQueryInterface.php
@@ -4,12 +4,13 @@ namespace DirectoryTree\ImapEngine;
 
 use BackedEnum;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
+use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
 
 /**
- * @mixin \DirectoryTree\ImapEngine\Connection\ImapQueryBuilder
+ * @mixin ImapQueryBuilder
  */
 interface MessageQueryInterface
 {

--- a/src/Support/BodyPartDecoder.php
+++ b/src/Support/BodyPartDecoder.php
@@ -45,4 +45,3 @@ class BodyPartDecoder
         return $parsed->getBinaryContentStream()?->getContents();
     }
 }
-

--- a/src/Support/BodyPartDecoder.php
+++ b/src/Support/BodyPartDecoder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace DirectoryTree\ImapEngine\Support;
+
+use DirectoryTree\ImapEngine\BodyStructurePart;
+use DirectoryTree\ImapEngine\MessageParser;
+
+class BodyPartDecoder
+{
+    /**
+     * Decode raw text/html content using the part's metadata.
+     */
+    public static function text(BodyStructurePart $part, ?string $content): ?string
+    {
+        $content = rtrim($content ?? '', "\r\n");
+
+        if ($content === '') {
+            return null;
+        }
+
+        $parsed = MessageParser::parse(
+            MimeMessage::make($part, $content)
+        );
+
+        return $part->subtype() === 'html'
+            ? $parsed->getHtmlContent()
+            : $parsed->getTextContent();
+    }
+
+    /**
+     * Decode raw binary content using the part's metadata.
+     */
+    public static function binary(BodyStructurePart $part, ?string $content): ?string
+    {
+        $content = rtrim($content ?? '', "\r\n");
+
+        if ($content === '') {
+            return null;
+        }
+
+        $parsed = MessageParser::parse(
+            MimeMessage::make($part, $content)
+        );
+
+        return $parsed->getBinaryContentStream()?->getContents();
+    }
+}
+

--- a/src/Support/LazyBodyPartStream.php
+++ b/src/Support/LazyBodyPartStream.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace DirectoryTree\ImapEngine\Support;
+
+use DirectoryTree\ImapEngine\BodyStructurePart;
+use DirectoryTree\ImapEngine\Message;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+class LazyBodyPartStream implements StreamInterface
+{
+    /**
+     * The current position in the stream.
+     */
+    protected int $position = 0;
+
+    /**
+     * The cached content.
+     */
+    protected ?string $content = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        protected Message $message,
+        protected BodyStructurePart $part,
+    ) {}
+
+    /**
+     * Fetch the content from the server if not already cached.
+     */
+    protected function fetchContent(): string
+    {
+        if ($this->content === null) {
+            $this->content = BodyPartDecoder::binary(
+                $this->part,
+                $this->message->bodyPart($this->part->partNumber())
+            ) ?? '';
+        }
+
+        return $this->content;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __toString(): string
+    {
+        return $this->getContents();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close(): void
+    {
+        $this->content = null;
+        $this->position = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function detach()
+    {
+        $this->close();
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSize(): ?int
+    {
+        return strlen($this->fetchContent());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tell(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function eof(): bool
+    {
+        return $this->position >= strlen($this->fetchContent());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSeekable(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function seek(int $offset, int $whence = SEEK_SET): void
+    {
+        $content = $this->fetchContent();
+        $size = strlen($content);
+
+        $this->position = match ($whence) {
+            SEEK_SET => $offset,
+            SEEK_CUR => $this->position + $offset,
+            SEEK_END => $size + $offset,
+            default => throw new RuntimeException('Invalid whence'),
+        };
+
+        if ($this->position < 0) {
+            $this->position = 0;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isWritable(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function read(int $length): string
+    {
+        $content = $this->fetchContent();
+
+        $result = substr($content, $this->position, $length);
+
+        $this->position += strlen($result);
+
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getContents(): string
+    {
+        $content = $this->fetchContent();
+
+        $result = substr($content, $this->position);
+
+        $this->position = strlen($content);
+
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadata(?string $key = null): mixed
+    {
+        return $key === null ? [] : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function write(string $string): int
+    {
+        throw new RuntimeException('Stream is not writable');
+    }
+}

--- a/src/Support/LazyBodyPartStream.php
+++ b/src/Support/LazyBodyPartStream.php
@@ -28,21 +28,6 @@ class LazyBodyPartStream implements StreamInterface
     ) {}
 
     /**
-     * Fetch the content from the server if not already cached.
-     */
-    protected function fetchContent(): string
-    {
-        if ($this->content === null) {
-            $this->content = BodyPartDecoder::binary(
-                $this->part,
-                $this->message->bodyPart($this->part->partNumber())
-            ) ?? '';
-        }
-
-        return $this->content;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function __toString(): string
@@ -74,7 +59,7 @@ class LazyBodyPartStream implements StreamInterface
      */
     public function getSize(): ?int
     {
-        return strlen($this->fetchContent());
+        return strlen($this->getOrFetchContent());
     }
 
     /**
@@ -90,7 +75,7 @@ class LazyBodyPartStream implements StreamInterface
      */
     public function eof(): bool
     {
-        return $this->position >= strlen($this->fetchContent());
+        return $this->position >= strlen($this->getOrFetchContent());
     }
 
     /**
@@ -106,7 +91,7 @@ class LazyBodyPartStream implements StreamInterface
      */
     public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        $content = $this->fetchContent();
+        $content = $this->getOrFetchContent();
         $size = strlen($content);
 
         $this->position = match ($whence) {
@@ -150,7 +135,7 @@ class LazyBodyPartStream implements StreamInterface
      */
     public function read(int $length): string
     {
-        $content = $this->fetchContent();
+        $content = $this->getOrFetchContent();
 
         $result = substr($content, $this->position, $length);
 
@@ -164,7 +149,7 @@ class LazyBodyPartStream implements StreamInterface
      */
     public function getContents(): string
     {
-        $content = $this->fetchContent();
+        $content = $this->getOrFetchContent();
 
         $result = substr($content, $this->position);
 
@@ -176,7 +161,7 @@ class LazyBodyPartStream implements StreamInterface
     /**
      * {@inheritDoc}
      */
-    public function getMetadata(?string $key = null): mixed
+    public function getMetadata(?string $key = null): ?array
     {
         return $key === null ? [] : null;
     }
@@ -187,5 +172,20 @@ class LazyBodyPartStream implements StreamInterface
     public function write(string $string): int
     {
         throw new RuntimeException('Stream is not writable');
+    }
+
+    /**
+     * Fetch the content from the server if not already cached.
+     */
+    protected function getOrFetchContent(): string
+    {
+        if ($this->content === null) {
+            $this->content = BodyPartDecoder::binary(
+                $this->part,
+                $this->message->bodyPart($this->part->partNumber())
+            ) ?? '';
+        }
+
+        return $this->content;
     }
 }

--- a/src/Support/MimeMessage.php
+++ b/src/Support/MimeMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DirectoryTree\ImapEngine\Support;
+
+use DirectoryTree\ImapEngine\BodyStructurePart;
+
+class MimeMessage
+{
+    /**
+     * Build a minimal MIME message from body structure metadata and raw content.
+     */
+    public static function make(BodyStructurePart $part, string $content): string
+    {
+        $headers = ["Content-Type: {$part->contentType()}"];
+
+        if ($charset = $part->charset()) {
+            $headers[0] .= "; charset=\"{$charset}\"";
+        }
+
+        if ($encoding = $part->encoding()) {
+            $headers[] = "Content-Transfer-Encoding: {$encoding}";
+        }
+
+        return implode("\r\n", $headers)."\r\n\r\n".$content;
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -24,6 +24,11 @@
 |
 */
 
+use DirectoryTree\ImapEngine\Connection\ImapParser;
+use DirectoryTree\ImapEngine\Connection\ImapTokenizer;
+use DirectoryTree\ImapEngine\Connection\Responses\Data\ListData;
+use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
+use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
 use DirectoryTree\ImapEngine\Mailbox;
 
 expect()->extend('toBeOne', function () {
@@ -56,4 +61,24 @@ function mailbox(array $config = []): Mailbox
         'password' => getenv('MAILBOX_PASSWORD'),
         'encryption' => getenv('MAILBOX_ENCRYPTION'),
     ]);
+}
+
+function parseBodyStructureResponse(string $response): ListData
+{
+    $stream = new FakeStream;
+    $stream->open();
+    $stream->feed([$response]);
+
+    $tokenizer = new ImapTokenizer($stream);
+    $parser = new ImapParser($tokenizer);
+
+    $parsed = $parser->next();
+
+    expect($parsed)->toBeInstanceOf(UntaggedResponse::class);
+
+    $data = $parsed->tokenAt(3);
+
+    expect($data)->toBeInstanceOf(ListData::class);
+
+    return $data->lookup('BODYSTRUCTURE');
 }

--- a/tests/Unit/BodyStructureTest.php
+++ b/tests/Unit/BodyStructureTest.php
@@ -2,31 +2,6 @@
 
 use DirectoryTree\ImapEngine\BodyStructureCollection;
 use DirectoryTree\ImapEngine\BodyStructurePart;
-use DirectoryTree\ImapEngine\Connection\ImapParser;
-use DirectoryTree\ImapEngine\Connection\ImapTokenizer;
-use DirectoryTree\ImapEngine\Connection\Responses\Data\ListData;
-use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
-use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
-
-function parseBodyStructureResponse(string $response): ListData
-{
-    $stream = new FakeStream;
-    $stream->open();
-    $stream->feed([$response]);
-
-    $tokenizer = new ImapTokenizer($stream);
-    $parser = new ImapParser($tokenizer);
-
-    $parsed = $parser->next();
-
-    expect($parsed)->toBeInstanceOf(UntaggedResponse::class);
-
-    $data = $parsed->tokenAt(3);
-
-    expect($data)->toBeInstanceOf(ListData::class);
-
-    return $data->lookup('BODYSTRUCTURE');
-}
 
 test('it parses a simple text/plain message as BodyStructurePart', function () {
     $listData = parseBodyStructureResponse(

--- a/tests/Unit/Connection/ImapConnectionTest.php
+++ b/tests/Unit/Connection/ImapConnectionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use DirectoryTree\ImapEngine\Collections\ResponseCollection;
 use DirectoryTree\ImapEngine\Connection\ImapConnection;
 use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
@@ -439,7 +440,7 @@ test('store flags', function () {
 
     $stream->assertWritten('TAG1 UID STORE 1:3 +FLAGS.SILENT (\\Seen)');
 
-    expect($response)->toBeInstanceOf(\DirectoryTree\ImapEngine\Collections\ResponseCollection::class);
+    expect($response)->toBeInstanceOf(ResponseCollection::class);
 });
 
 test('uid fetch with uid', function () {

--- a/tests/Unit/MessageTest.php
+++ b/tests/Unit/MessageTest.php
@@ -464,3 +464,42 @@ test('it fetches body structure automatically for html when not preloaded', func
     expect($message->hasBodyStructure())->toBeFalse();
     expect($message->html(lazy: true))->toBe('<p>Hello World!</p>');
 });
+
+test('it lazy loads attachments from body structure', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $encodedContent = base64_encode('Hello World!');
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* 1 FETCH (UID 1 BODY[2] {'.(strlen($encodedContent) + 2).'}',
+        $encodedContent,
+        ')',
+        'TAG2 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    // Multipart mixed with text/plain at part 1 and PDF attachment at part 2
+    $bodyStructureData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE (("text" "plain" ("charset" "utf-8") NIL NIL "7bit" 100 5 NIL NIL NIL) ("application" "pdf" ("name" "document.pdf") NIL NIL "base64" 5000 NIL ("attachment" ("filename" "document.pdf")) NIL NIL) "mixed" ("boundary" "abc") NIL NIL) UID 1)'
+    );
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '', null, $bodyStructureData);
+
+    expect($message->hasBody())->toBeFalse();
+    expect($message->hasBodyStructure())->toBeTrue();
+
+    $attachments = $message->attachments(lazy: true);
+
+    expect($attachments)->toHaveCount(1);
+    expect($attachments[0]->filename())->toBe('document.pdf');
+    expect($attachments[0]->contentType())->toBe('application/pdf');
+
+    // Content is fetched lazily when contents() is called
+    expect($attachments[0]->contents())->toBe('Hello World!');
+});

--- a/tests/Unit/MessageTest.php
+++ b/tests/Unit/MessageTest.php
@@ -177,3 +177,290 @@ test('it serializes and unserializes the message correctly', function () {
     expect($unserializedMessage->body())->toBe('This is the message body content');
     expect($unserializedMessage->size())->toBe(1024);
 });
+
+test('it lazy loads text content from body structure when body is not loaded', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* 1 FETCH (UID 1 BODY[1] {12}',
+        'Hello World!',
+        ')',
+        'TAG2 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $bodyStructureData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE ("text" "plain" ("charset" "utf-8") NIL NIL "7bit" 12 1 NIL NIL NIL) UID 1)'
+    );
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '', null, $bodyStructureData);
+
+    expect($message->hasBody())->toBeFalse();
+    expect($message->hasBodyStructure())->toBeTrue();
+    expect($message->text(lazy: true))->toBe('Hello World!');
+});
+
+test('it lazy loads html content from body structure when body is not loaded', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* 1 FETCH (UID 1 BODY[1] {21}',
+        '<p>Hello World!</p>',
+        ')',
+        'TAG2 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $bodyStructureData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE ("text" "html" ("charset" "utf-8") NIL NIL "7bit" 19 1 NIL NIL NIL) UID 1)'
+    );
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '', null, $bodyStructureData);
+
+    expect($message->hasBody())->toBeFalse();
+    expect($message->hasBodyStructure())->toBeTrue();
+    expect($message->html(lazy: true))->toBe('<p>Hello World!</p>');
+});
+
+test('it decodes base64 encoded content when lazy loading', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $encodedContent = base64_encode('Hello World!');
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* 1 FETCH (UID 1 BODY[1] {'.(strlen($encodedContent) + 2).'}',
+        $encodedContent,
+        ')',
+        'TAG2 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $bodyStructureData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE ("text" "plain" ("charset" "utf-8") NIL NIL "base64" 16 1 NIL NIL NIL) UID 1)'
+    );
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '', null, $bodyStructureData);
+
+    expect($message->text(lazy: true))->toBe('Hello World!');
+});
+
+test('it decodes quoted-printable encoded content when lazy loading', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $encodedContent = 'Hello=20World!';
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* 1 FETCH (UID 1 BODY[1] {'.(strlen($encodedContent) + 2).'}',
+        $encodedContent,
+        ')',
+        'TAG2 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $bodyStructureData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE ("text" "plain" ("charset" "utf-8") NIL NIL "quoted-printable" 14 1 NIL NIL NIL) UID 1)'
+    );
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '', null, $bodyStructureData);
+
+    expect($message->text(lazy: true))->toBe('Hello World!');
+});
+
+test('it converts charset to utf-8 when lazy loading', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    // ISO-8859-1 encoded content with special character
+    $originalContent = 'Café';
+    $encodedContent = mb_convert_encoding($originalContent, 'ISO-8859-1', 'UTF-8');
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* 1 FETCH (UID 1 BODY[1] {'.(strlen($encodedContent) + 2).'}',
+        $encodedContent,
+        ')',
+        'TAG2 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $bodyStructureData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE ("text" "plain" ("charset" "iso-8859-1") NIL NIL "7bit" 5 1 NIL NIL NIL) UID 1)'
+    );
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '', null, $bodyStructureData);
+
+    expect($message->text(lazy: true))->toBe($originalContent);
+});
+
+test('it uses parsed body when body is already loaded', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $head = <<<'HEAD'
+From: test@example.com
+To: recipient@example.com
+Subject: Test
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+HEAD;
+
+    $body = 'Hello from parsed body!';
+
+    $message = new Message($folder, 1, [], $head, $body);
+
+    expect($message->hasBody())->toBeTrue();
+    expect($message->text())->toBe('Hello from parsed body!');
+});
+
+test('it lazy loads text from multipart message body structure', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* 1 FETCH (UID 1 BODY[1] {14}',
+        'Hello World!',
+        ')',
+        'TAG2 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    // Multipart alternative with text/plain at part 1 and text/html at part 2
+    $bodyStructureData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE (("text" "plain" ("charset" "utf-8") NIL NIL "7bit" 12 1 NIL NIL NIL) ("text" "html" ("charset" "utf-8") NIL NIL "7bit" 24 1 NIL NIL NIL) "alternative" ("boundary" "abc") NIL NIL) UID 1)'
+    );
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '', null, $bodyStructureData);
+
+    expect($message->hasBody())->toBeFalse();
+    expect($message->hasBodyStructure())->toBeTrue();
+    expect($message->text(lazy: true))->toBe('Hello World!');
+});
+
+test('it lazy loads html from multipart message body structure', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* 1 FETCH (UID 1 BODY[2] {21}',
+        '<p>Hello World!</p>',
+        ')',
+        'TAG2 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    // Multipart alternative with text/plain at part 1 and text/html at part 2
+    $bodyStructureData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE (("text" "plain" ("charset" "utf-8") NIL NIL "7bit" 12 1 NIL NIL NIL) ("text" "html" ("charset" "utf-8") NIL NIL "7bit" 19 1 NIL NIL NIL) "alternative" ("boundary" "abc") NIL NIL) UID 1)'
+    );
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '', null, $bodyStructureData);
+
+    expect($message->html(lazy: true))->toBe('<p>Hello World!</p>');
+});
+
+test('it fetches body structure automatically when not preloaded', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    // This simulates a message fetched without withBodyStructure(), then accessing text()
+    // The server will respond with: 1) body structure fetch, 2) body part fetch
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        // Response for BODYSTRUCTURE fetch
+        '* 1 FETCH (UID 1 BODYSTRUCTURE ("text" "plain" ("charset" "utf-8") NIL NIL "7bit" 12 1 NIL NIL NIL))',
+        'TAG2 OK FETCH completed',
+        // Response for BODY[1] fetch
+        '* 1 FETCH (UID 1 BODY[1] {14}',
+        'Hello World!',
+        ')',
+        'TAG3 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    // Message created without body structure data - simulates fetching without withBodyStructure()
+    $message = new Message($folder, 1, [], 'From: test@example.com', '');
+
+    expect($message->hasBody())->toBeFalse();
+    expect($message->hasBodyStructure())->toBeFalse();
+
+    // This should automatically fetch body structure, then fetch and decode the text part
+    expect($message->text(lazy: true))->toBe('Hello World!');
+});
+
+test('it fetches body structure automatically for html when not preloaded', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $mailbox->connect(ImapConnection::fake([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        // Response for BODYSTRUCTURE fetch
+        '* 1 FETCH (UID 1 BODYSTRUCTURE ("text" "html" ("charset" "utf-8") NIL NIL "7bit" 19 1 NIL NIL NIL))',
+        'TAG2 OK FETCH completed',
+        // Response for BODY[1] fetch
+        '* 1 FETCH (UID 1 BODY[1] {21}',
+        '<p>Hello World!</p>',
+        ')',
+        'TAG3 OK FETCH completed',
+    ]));
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $message = new Message($folder, 1, [], 'From: test@example.com', '');
+
+    expect($message->hasBodyStructure())->toBeFalse();
+    expect($message->html(lazy: true))->toBe('<p>Hello World!</p>');
+});

--- a/tests/Unit/MimeMessageTest.php
+++ b/tests/Unit/MimeMessageTest.php
@@ -82,4 +82,3 @@ test('it builds mime message with iso-8859-1 charset', function () {
 
     expect($mime)->toBe("Content-Type: text/plain; charset=\"iso-8859-1\"\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\nCaf=E9");
 });
-

--- a/tests/Unit/MimeMessageTest.php
+++ b/tests/Unit/MimeMessageTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use DirectoryTree\ImapEngine\BodyStructurePart;
+use DirectoryTree\ImapEngine\Support\MimeMessage;
+
+test('it builds mime message with content type', function () {
+    $part = new BodyStructurePart(
+        partNumber: '1',
+        type: 'text',
+        subtype: 'plain',
+    );
+
+    $mime = MimeMessage::make($part, 'Hello World!');
+
+    expect($mime)->toBe("Content-Type: text/plain\r\n\r\nHello World!");
+});
+
+test('it builds mime message with charset', function () {
+    $part = new BodyStructurePart(
+        partNumber: '1',
+        type: 'text',
+        subtype: 'plain',
+        parameters: ['charset' => 'utf-8'],
+    );
+
+    $mime = MimeMessage::make($part, 'Hello World!');
+
+    expect($mime)->toBe("Content-Type: text/plain; charset=\"utf-8\"\r\n\r\nHello World!");
+});
+
+test('it builds mime message with transfer encoding', function () {
+    $part = new BodyStructurePart(
+        partNumber: '1',
+        type: 'text',
+        subtype: 'plain',
+        encoding: 'base64',
+    );
+
+    $mime = MimeMessage::make($part, 'SGVsbG8gV29ybGQh');
+
+    expect($mime)->toBe("Content-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\n\r\nSGVsbG8gV29ybGQh");
+});
+
+test('it builds mime message with charset and transfer encoding', function () {
+    $part = new BodyStructurePart(
+        partNumber: '1',
+        type: 'text',
+        subtype: 'plain',
+        parameters: ['charset' => 'utf-8'],
+        encoding: 'quoted-printable',
+    );
+
+    $mime = MimeMessage::make($part, 'Hello=20World!');
+
+    expect($mime)->toBe("Content-Type: text/plain; charset=\"utf-8\"\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\nHello=20World!");
+});
+
+test('it builds mime message for html content', function () {
+    $part = new BodyStructurePart(
+        partNumber: '1',
+        type: 'text',
+        subtype: 'html',
+        parameters: ['charset' => 'utf-8'],
+        encoding: '7bit',
+    );
+
+    $mime = MimeMessage::make($part, '<p>Hello World!</p>');
+
+    expect($mime)->toBe("Content-Type: text/html; charset=\"utf-8\"\r\nContent-Transfer-Encoding: 7bit\r\n\r\n<p>Hello World!</p>");
+});
+
+test('it builds mime message with iso-8859-1 charset', function () {
+    $part = new BodyStructurePart(
+        partNumber: '1',
+        type: 'text',
+        subtype: 'plain',
+        parameters: ['charset' => 'iso-8859-1'],
+        encoding: 'quoted-printable',
+    );
+
+    $mime = MimeMessage::make($part, 'Caf=E9');
+
+    expect($mime)->toBe("Content-Type: text/plain; charset=\"iso-8859-1\"\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\nCaf=E9");
+});
+


### PR DESCRIPTION
Closes #153 

This PR adds the ability to lazy-load message contents using the first parameter of the `text()`, `html()`, `attachments()`, and `bodyStructure()` methods. This gives developers the opportunity to fetch thin messages containing only their UID first, and then lazy load the required content easily:

```php
$message = $inbox->messages()->first();

$text = $message->text(lazy: true);
$html = $message->html(lazy: true);
$parts = $message->bodyStructure(lazy: true);
$attachments = $message->attachments(lazy: true);
```