### PR TITLE
Fix UID infinity search range returning last message

### DIFF
--- a/src/Connection/ImapQueryBuilder.php
+++ b/src/Connection/ImapQueryBuilder.php
@@ -12,6 +12,11 @@ use DirectoryTree\ImapEngine\Support\Str;
 class ImapQueryBuilder
 {
     /**
+     * The largest UID value allowed by IMAP.
+     */
+    protected const MAX_UID = '4294967295';
+
+    /**
      * The where conditions for the query.
      */
     protected array $wheres = [];
@@ -270,6 +275,10 @@ class ImapQueryBuilder
      */
     public function uid(int|string|array $from, int|float|null $to = null): static
     {
+        if ($to === INF) {
+            $to = self::MAX_UID;
+        }
+
         return $this->where(ImapSearchKey::Uid, new RawQueryValue(Str::set($from, $to)));
     }
 

--- a/tests/Unit/Connection/ImapQueryBuilderTest.php
+++ b/tests/Unit/Connection/ImapQueryBuilderTest.php
@@ -245,12 +245,12 @@ test('compiles multiple UID values without quotes', function () {
     expect($builder->toImap())->toBe('UID 2,3,5');
 });
 
-test('compiles UID range to infinity with from and to', function () {
+test('compiles UID range to infinity with from and to as a numeric upper bound', function () {
     $builder = new ImapQueryBuilder;
 
     $builder->uid(2, INF);
 
-    expect($builder->toImap())->toBe('UID 2:*');
+    expect($builder->toImap())->toBe('UID 2:4294967295');
 });
 
 test('compiles UID range with upper bound with array', function () {

--- a/tests/Unit/MessageQueryTest.php
+++ b/tests/Unit/MessageQueryTest.php
@@ -331,6 +331,26 @@ test('markFlagged flags all matching messages', function () {
     $stream->assertWritten('TAG3 UID STORE 5,6,7,8 +FLAGS.SILENT (\Flagged)');
 });
 
+test('uid range to infinity searches with numeric upper bound', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* SEARCH',
+        'TAG2 OK SEARCH completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    $messages = query($mailbox)->uid(42, INF)->get();
+
+    expect($messages)->toBeEmpty();
+    $stream->assertWritten('TAG2 UID SEARCH UID 42:4294967295');
+});
+
 test('unmarkFlagged unflags all matching messages', function () {
     $stream = new FakeStream;
     $stream->open();


### PR DESCRIPTION
Closes #157 

This PR fixes `uid($next, INF)` compiling to `UID $next:*`, which can return the current last message when `$next` is `UIDNEXT`.

In IMAP, `*` in a UID range refers to the highest existing UID, and ranges are inclusive regardless of order. This means `UIDNEXT:*` can still match the last existing message. The query now compiles `INF` to the maximum IMAP UID value (`4294967295`) for UID searches.