### PR TITLE
Add message ID query helper

### DIFF
--- a/src/Connection/ImapQueryBuilder.php
+++ b/src/Connection/ImapQueryBuilder.php
@@ -271,6 +271,14 @@ class ImapQueryBuilder
     }
 
     /**
+     * Add a where "HEADER Message-ID" clause to the query.
+     */
+    public function messageId(string $messageId): static
+    {
+        return $this->header('Message-ID', trim(trim($messageId), '<>'));
+    }
+
+    /**
      * Add a where "UID" clause to the query.
      */
     public function uid(int|string|array $from, int|float|null $to = null): static

--- a/tests/Unit/Connection/ImapQueryBuilderTest.php
+++ b/tests/Unit/Connection/ImapQueryBuilderTest.php
@@ -221,6 +221,17 @@ test('compiles raw value', function () {
     expect($builder->toImap())->toBe('FOO bar');
 });
 
+test('compiles message id condition', function (string $messageId) {
+    $builder = new ImapQueryBuilder;
+
+    $builder->messageId($messageId);
+
+    expect($builder->toImap())->toBe('HEADER MESSAGE-ID "unique-message-id@server.example.com"');
+})->with([
+    'bare message id' => ['unique-message-id@server.example.com'],
+    'wrapped message id' => ['<unique-message-id@server.example.com>'],
+]);
+
 test('converts values from utf-8 to utf-7', function () {
     $builder = new ImapQueryBuilder;
 

--- a/tests/Unit/MessageQueryTest.php
+++ b/tests/Unit/MessageQueryTest.php
@@ -33,6 +33,13 @@ test('where', function () {
     expect($query)->toBe('SUBJECT "hello"');
 });
 
+test('message id forwards to query builder', function () {
+    $query = query();
+
+    expect($query->messageId('unique-message-id@server.example.com'))->toBe($query);
+    expect($query->toImap())->toBe('HEADER MESSAGE-ID "unique-message-id@server.example.com"');
+});
+
 test('destroy', function () {
     $stream = new FakeStream;
     $stream->open();


### PR DESCRIPTION
## Summary

Adds a `messageId()` query helper so developers can search for messages by the email `Message-ID` header without confusing it with an IMAP UID or message sequence number.

The helper accepts either a bare message ID like `unique-message-id@example.com` or a wrapped value like `<unique-message-id@example.com>`, normalizes it to the bare value, and compiles the expected IMAP header search:

```php
HEADER Message-ID "unique-message-id@example.com"
```

## Why

`MessageQuery::find()` works with numeric IMAP identifiers. A message's `Message-ID` is an email header, so it should be queried through `SEARCH HEADER Message-ID ...` instead of through `find()` or a new fetch identifier.

Closes #82.

## Tests

- `./vendor/bin/pest tests/Unit/Connection/ImapQueryBuilderTest.php tests/Unit/MessageQueryTest.php`
- `./vendor/bin/pest tests/Unit`