### PR TITLE
Fix repeated attachment content reads

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -117,6 +117,10 @@ class Attachment implements Arrayable, JsonSerializable
      */
     public function contents(): string
     {
+        if ($this->contentStream->isSeekable()) {
+            $this->contentStream->rewind();
+        }
+
         return $this->contentStream->getContents();
     }
 

--- a/tests/Unit/AttachmentTest.php
+++ b/tests/Unit/AttachmentTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use DirectoryTree\ImapEngine\Attachment;
-use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\Psr7\Utils;
 
 test('extension', function () {
-    $stream = new LazyOpenStream('test.jpg', 'r');
+    $stream = Utils::streamFor('');
 
     $ext = (new Attachment('test.jpg', null, 'image/jpeg', 'attachment', $stream))->extension();
 
@@ -12,9 +12,33 @@ test('extension', function () {
 });
 
 test('extension with content type', function () {
-    $stream = new LazyOpenStream('test', 'r');
+    $stream = Utils::streamFor('');
 
     $ext = (new Attachment('test', null, 'image/jpeg', 'attachment', $stream))->extension();
 
     expect($ext)->toBe('jpg');
+});
+
+test('contents can be read multiple times', function () {
+    $stream = Utils::streamFor('Hello World!');
+
+    $attachment = new Attachment('test.txt', null, 'text/plain', 'attachment', $stream);
+
+    expect($attachment->contents())->toBe('Hello World!');
+    expect($attachment->contents())->toBe('Hello World!');
+});
+
+test('save writes contents after reading contents', function () {
+    $stream = Utils::streamFor('Hello World!');
+
+    $attachment = new Attachment('test.txt', null, 'text/plain', 'attachment', $stream);
+
+    $path = tempnam(sys_get_temp_dir(), 'imap-engine-attachment-');
+
+    $attachment->contents();
+    $attachment->save($path);
+
+    expect(file_get_contents($path))->toBe('Hello World!');
+
+    unlink($path);
 });


### PR DESCRIPTION
## Description

Fixes #166.

Calling `Attachment::contents()` currently drains the underlying PSR-7 stream because `getContents()` reads from the stream's current cursor position to the end. If a developer reads an attachment's contents first and then calls `save()`, the stream cursor is already at EOF, so the saved file is created with zero bytes.

This updates `Attachment::contents()` to rewind seekable streams before reading, so the high-level attachment API consistently returns the full attachment contents. Developers who need raw cursor-based stream behavior can still access the stream directly through `contentStream()`.

## Tests

- `vendor/bin/pest tests/Unit/AttachmentTest.php`
- `vendor/bin/pest tests/Unit`