### PR TITLE
Decode RFC 2231 MIME parameters

### DIFF
--- a/src/BodyStructureCollection.php
+++ b/src/BodyStructureCollection.php
@@ -6,6 +6,7 @@ use Countable;
 use DirectoryTree\ImapEngine\Connection\Responses\Data\ListData;
 use DirectoryTree\ImapEngine\Connection\Tokens\Nil;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
+use DirectoryTree\ImapEngine\Support\MimeParameterParser;
 use Illuminate\Contracts\Support\Arrayable;
 use IteratorAggregate;
 use JsonSerializable;
@@ -63,7 +64,7 @@ class BodyStructureCollection implements Arrayable, Countable, IteratorAggregate
         if ($subtypeIndex) {
             foreach (array_slice($tokens, $subtypeIndex + 1) as $token) {
                 if ($token instanceof ListData && ! static::isDispositionList($token)) {
-                    $parameters = $token->toKeyValuePairs();
+                    $parameters = MimeParameterParser::parse($token->toKeyValuePairs());
 
                     break;
                 }

--- a/src/BodyStructurePart.php
+++ b/src/BodyStructurePart.php
@@ -6,6 +6,7 @@ use DirectoryTree\ImapEngine\Connection\Responses\Data\ListData;
 use DirectoryTree\ImapEngine\Connection\Tokens\Nil;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 use DirectoryTree\ImapEngine\Support\MimeParameterParser;
+use DirectoryTree\ImapEngine\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 
@@ -42,6 +43,8 @@ class BodyStructurePart implements Arrayable, JsonSerializable
      */
     protected static function parse(array $tokens, string $partNumber): static
     {
+        $description = static::tokenValueAt($tokens, 4);
+
         return new static(
             partNumber: $partNumber,
             type: strtolower(static::tokenValueAt($tokens, 0) ?? 'text'),
@@ -50,7 +53,7 @@ class BodyStructurePart implements Arrayable, JsonSerializable
                 ? MimeParameterParser::parse($tokens[2]->toKeyValuePairs())
                 : [],
             id: static::tokenValueAt($tokens, 3),
-            description: static::tokenValueAt($tokens, 4),
+            description: $description === null ? null : Str::decodeMimeHeader($description),
             encoding: static::tokenValueAt($tokens, 5),
             size: static::tokenIntValueAt($tokens, 6),
             lines: static::tokenIntValueAt($tokens, 7),

--- a/src/BodyStructurePart.php
+++ b/src/BodyStructurePart.php
@@ -43,8 +43,6 @@ class BodyStructurePart implements Arrayable, JsonSerializable
      */
     protected static function parse(array $tokens, string $partNumber): static
     {
-        $description = static::tokenValueAt($tokens, 4);
-
         return new static(
             partNumber: $partNumber,
             type: strtolower(static::tokenValueAt($tokens, 0) ?? 'text'),
@@ -53,7 +51,7 @@ class BodyStructurePart implements Arrayable, JsonSerializable
                 ? MimeParameterParser::parse($tokens[2]->toKeyValuePairs())
                 : [],
             id: static::tokenValueAt($tokens, 3),
-            description: $description === null ? null : Str::decodeMimeHeader($description),
+            description: Str::decodeMimeHeader(static::tokenValueAt($tokens, 4) ?? ''),
             encoding: static::tokenValueAt($tokens, 5),
             size: static::tokenIntValueAt($tokens, 6),
             lines: static::tokenIntValueAt($tokens, 7),

--- a/src/BodyStructurePart.php
+++ b/src/BodyStructurePart.php
@@ -51,7 +51,9 @@ class BodyStructurePart implements Arrayable, JsonSerializable
                 ? MimeParameterParser::parse($tokens[2]->toKeyValuePairs())
                 : [],
             id: static::tokenValueAt($tokens, 3),
-            description: Str::decodeMimeHeader(static::tokenValueAt($tokens, 4) ?? ''),
+            description: is_null($description = static::tokenValueAt($tokens, 4))
+                 ? null
+                 : Str::decodeMimeHeader($description),
             encoding: static::tokenValueAt($tokens, 5),
             size: static::tokenIntValueAt($tokens, 6),
             lines: static::tokenIntValueAt($tokens, 7),
@@ -66,7 +68,9 @@ class BodyStructurePart implements Arrayable, JsonSerializable
      */
     protected static function tokenValueAt(array $tokens, int $index): ?string
     {
-        $token = $tokens[$index] ?? null;
+        if (is_null($token = $tokens[$index] ?? null)) {
+            return null;
+        }
 
         if (! $token instanceof Token || $token instanceof Nil) {
             return null;
@@ -84,7 +88,7 @@ class BodyStructurePart implements Arrayable, JsonSerializable
     {
         $value = static::tokenValueAt($tokens, $index);
 
-        return $value === null ? null : (int) $value;
+        return is_null($value) ? null : (int) $value;
     }
 
     /**

--- a/src/BodyStructurePart.php
+++ b/src/BodyStructurePart.php
@@ -5,6 +5,7 @@ namespace DirectoryTree\ImapEngine;
 use DirectoryTree\ImapEngine\Connection\Responses\Data\ListData;
 use DirectoryTree\ImapEngine\Connection\Tokens\Nil;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
+use DirectoryTree\ImapEngine\Support\MimeParameterParser;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 
@@ -45,7 +46,9 @@ class BodyStructurePart implements Arrayable, JsonSerializable
             partNumber: $partNumber,
             type: strtolower(static::tokenValueAt($tokens, 0) ?? 'text'),
             subtype: strtolower(static::tokenValueAt($tokens, 1) ?? 'plain'),
-            parameters: isset($tokens[2]) && $tokens[2] instanceof ListData ? $tokens[2]->toKeyValuePairs() : [],
+            parameters: isset($tokens[2]) && $tokens[2] instanceof ListData
+                ? MimeParameterParser::parse($tokens[2]->toKeyValuePairs())
+                : [],
             id: static::tokenValueAt($tokens, 3),
             description: static::tokenValueAt($tokens, 4),
             encoding: static::tokenValueAt($tokens, 5),
@@ -184,7 +187,7 @@ class BodyStructurePart implements Arrayable, JsonSerializable
      */
     public function filename(): ?string
     {
-        return $this->disposition?->filename() ?? $this->parameters['name'] ?? null;
+        return $this->disposition?->filename() ?? $this->parameter('name');
     }
 
     /**

--- a/src/ContentDisposition.php
+++ b/src/ContentDisposition.php
@@ -5,6 +5,7 @@ namespace DirectoryTree\ImapEngine;
 use DirectoryTree\ImapEngine\Connection\Responses\Data\ListData;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 use DirectoryTree\ImapEngine\Enums\ContentDispositionType;
+use DirectoryTree\ImapEngine\Support\MimeParameterParser;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 
@@ -44,7 +45,7 @@ class ContentDisposition implements Arrayable, JsonSerializable
             }
 
             $parameters = isset($innerTokens[1]) && $innerTokens[1] instanceof ListData
-                ? $innerTokens[1]->toKeyValuePairs()
+                ? MimeParameterParser::parse($innerTokens[1]->toKeyValuePairs())
                 : [];
 
             return new self($type, $parameters);
@@ -82,7 +83,7 @@ class ContentDisposition implements Arrayable, JsonSerializable
      */
     public function filename(): ?string
     {
-        return $this->parameters['filename'] ?? null;
+        return $this->parameter('filename');
     }
 
     /**

--- a/src/Support/MimeParameterParser.php
+++ b/src/Support/MimeParameterParser.php
@@ -14,7 +14,7 @@ class MimeParameterParser
      */
     public static function parse(array $parameters): array
     {
-        if ($parameters === []) {
+        if (empty($parameters)) {
             return [];
         }
 
@@ -32,9 +32,7 @@ class MimeParameterParser
                 continue;
             }
 
-            $value = $header->getValueFor($name);
-
-            if ($value !== null) {
+            if (! is_null($value = $header->getValueFor($name))) {
                 $parsed[$name] = $value;
             }
         }

--- a/src/Support/MimeParameterParser.php
+++ b/src/Support/MimeParameterParser.php
@@ -53,17 +53,9 @@ class MimeParameterParser
         $values = [];
 
         foreach ($parameters as $name => $value) {
-            $values[] = sprintf('%s="%s"', $name, static::escape($value));
+            $values[] = sprintf('%s="%s"', $name, Str::escape($value));
         }
 
         return $values;
-    }
-
-    /**
-     * Escape a MIME quoted-string value.
-     */
-    protected static function escape(string $value): string
-    {
-        return str_replace(['\\', '"'], ['\\\\', '\\"'], $value);
     }
 }

--- a/src/Support/MimeParameterParser.php
+++ b/src/Support/MimeParameterParser.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace DirectoryTree\ImapEngine\Support;
+
+use ZBateson\MailMimeParser\Header\ParameterHeader;
+
+class MimeParameterParser
+{
+    /**
+     * Parse and normalize MIME parameters.
+     *
+     * @param  array<string, string>  $parameters
+     * @return array<string, string>
+     */
+    public static function parse(array $parameters): array
+    {
+        if ($parameters === []) {
+            return [];
+        }
+
+        $header = new ParameterHeader(
+            'Content-Type',
+            'application/octet-stream; '.implode('; ', static::stringify($parameters))
+        );
+
+        $parsed = [];
+
+        foreach (array_keys($parameters) as $name) {
+            $name = strtolower(explode('*', $name, 2)[0]);
+
+            if (array_key_exists($name, $parsed)) {
+                continue;
+            }
+
+            $value = $header->getValueFor($name);
+
+            if ($value !== null) {
+                $parsed[$name] = $value;
+            }
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Convert parameter values into MIME parameter syntax.
+     *
+     * @param  array<string, string>  $parameters
+     * @return string[]
+     */
+    protected static function stringify(array $parameters): array
+    {
+        $values = [];
+
+        foreach ($parameters as $name => $value) {
+            $values[] = sprintf('%s="%s"', $name, static::escape($value));
+        }
+
+        return $values;
+    }
+
+    /**
+     * Escape a MIME quoted-string value.
+     */
+    protected static function escape(string $value): string
+    {
+        return str_replace(['\\', '"'], ['\\\\', '\\"'], $value);
+    }
+}

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -300,6 +300,10 @@ class Str
      */
     public static function decodeMimeHeader(string $value): string
     {
+        if (empty($value)) {
+            return $value;
+        }
+
         if (! str_contains($value, '=?')) {
             return $value;
         }

--- a/tests/Unit/BodyStructureTest.php
+++ b/tests/Unit/BodyStructureTest.php
@@ -17,6 +17,29 @@ test('it parses a simple text/plain message as BodyStructurePart', function () {
     expect($part->size())->toBe(100);
     expect($part->lines())->toBe(5);
     expect($part->partNumber())->toBe('1');
+    expect($part->description())->toBeNull();
+});
+
+test('it preserves plain content descriptions', function () {
+    $listData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE ("application" "pdf" NIL NIL "A PDF invoice" "base64" 5000 NIL NIL NIL NIL) UID 1)'
+    );
+
+    $part = BodyStructurePart::fromListData($listData);
+
+    expect($part->description())->toBe('A PDF invoice');
+    expect($part->toArray()['description'])->toBe('A PDF invoice');
+});
+
+test('it decodes MIME encoded content descriptions', function () {
+    $listData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE ("application" "pdf" NIL NIL "=?iso-8859-1?Q?123456_-_von_Beispiel_GmbH_vom_01.01.2025_Pauschale?= =?iso-8859-1?Q?_f=FCr_Zustellungen=5F.pdf?=" "base64" 5000 NIL NIL NIL NIL) UID 1)'
+    );
+
+    $part = BodyStructurePart::fromListData($listData);
+
+    expect($part->description())->toBe('123456 - von Beispiel GmbH vom 01.01.2025 Pauschale für Zustellungen_.pdf');
+    expect($part->toArray()['description'])->toBe('123456 - von Beispiel GmbH vom 01.01.2025 Pauschale für Zustellungen_.pdf');
 });
 
 test('it parses a multipart/alternative message as BodyStructureCollection', function () {

--- a/tests/Unit/BodyStructureTest.php
+++ b/tests/Unit/BodyStructureTest.php
@@ -84,6 +84,37 @@ test('it detects attachments in a collection', function () {
     expect($attachments[0]->contentType())->toBe('application/pdf');
 });
 
+test('it decodes continued attachment filenames', function () {
+    $listData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE (("text" "plain" ("charset" "utf-8") NIL NIL "7bit" 100 5 NIL NIL NIL) ("application" "pdf" ("name*1" "attachment_name_part_1.pdf" "name*0" "attachment_name_part_0") NIL NIL "base64" 5000 NIL ("attachment" ("filename*1" "attachment_name_part_1.pdf" "filename*0" "attachment_name_part_0")) NIL NIL) "mixed" ("boundary" "abc") NIL NIL) UID 1)'
+    );
+
+    $collection = BodyStructureCollection::fromListData($listData);
+    $attachment = $collection->attachments()[0];
+
+    expect($attachment->filename())->toBe('attachment_name_part_0attachment_name_part_1.pdf');
+    expect($attachment->parameters())->toBe([
+        'name' => 'attachment_name_part_0attachment_name_part_1.pdf',
+    ]);
+    expect($attachment->disposition()?->parameters())->toBe([
+        'filename' => 'attachment_name_part_0attachment_name_part_1.pdf',
+    ]);
+});
+
+test('it decodes extended content type names when no disposition is present', function () {
+    $listData = parseBodyStructureResponse(
+        '* 1 FETCH (BODYSTRUCTURE (("text" "plain" ("charset" "utf-8") NIL NIL "7bit" 100 5 NIL NIL NIL) ("application" "pdf" ("name*1" "2026.pdf" "name*0*" "utf-8\'\'invoice%20") NIL NIL "base64" 5000 NIL NIL NIL NIL) "mixed" ("boundary" "abc") NIL NIL) UID 1)'
+    );
+
+    $collection = BodyStructureCollection::fromListData($listData);
+    $attachment = $collection->attachments()[0];
+
+    expect($attachment->filename())->toBe('invoice 2026.pdf');
+    expect($attachment->parameters())->toBe([
+        'name' => 'invoice 2026.pdf',
+    ]);
+});
+
 test('it converts BodyStructurePart to array', function () {
     $listData = parseBodyStructureResponse(
         '* 1 FETCH (BODYSTRUCTURE ("text" "plain" ("charset" "utf-8") NIL NIL "7bit" 100 5 NIL NIL NIL) UID 1)'

--- a/tests/Unit/Support/MimeParameterParserTest.php
+++ b/tests/Unit/Support/MimeParameterParserTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use DirectoryTree\ImapEngine\Support\MimeParameterParser;
+
+test('it parses regular parameters', function () {
+    $parameters = MimeParameterParser::parse([
+        'charset' => 'utf-8',
+        'name' => 'document.pdf',
+    ]);
+
+    expect($parameters)->toBe([
+        'charset' => 'utf-8',
+        'name' => 'document.pdf',
+    ]);
+});
+
+test('it combines RFC 2231 parameter continuations in numerical order', function () {
+    $parameters = MimeParameterParser::parse([
+        'filename*1' => 'attachment_name_part_1.pdf',
+        'filename*0' => 'attachment_name_part_0',
+    ]);
+
+    expect($parameters)->toBe([
+        'filename' => 'attachment_name_part_0attachment_name_part_1.pdf',
+    ]);
+});
+
+test('it decodes RFC 2231 extended parameter continuations', function () {
+    $parameters = MimeParameterParser::parse([
+        'filename*1*' => '2026.pdf',
+        'filename*0*' => "utf-8''invoice%20",
+    ]);
+
+    expect($parameters)->toBe([
+        'filename' => 'invoice 2026.pdf',
+    ]);
+});
+
+test('it decodes standalone RFC 2231 extended parameters', function () {
+    $parameters = MimeParameterParser::parse([
+        'filename*' => "utf-8''invoice%202026.pdf",
+    ]);
+
+    expect($parameters)->toBe([
+        'filename' => 'invoice 2026.pdf',
+    ]);
+});
+
+test('it converts RFC 2231 parameter values to UTF-8', function () {
+    $parameters = MimeParameterParser::parse([
+        'filename*' => "iso-8859-1''f%FCr%20Zustellungen.pdf",
+    ]);
+
+    expect($parameters)->toBe([
+        'filename' => 'für Zustellungen.pdf',
+    ]);
+});
+
+test('it decodes MIME encoded parameter values for compatibility', function () {
+    $parameters = MimeParameterParser::parse([
+        'filename' => '=?iso-8859-1?Q?f=FCr_Zustellungen.pdf?=',
+    ]);
+
+    expect($parameters)->toBe([
+        'filename' => 'für Zustellungen.pdf',
+    ]);
+});
+
+test('it preserves MIME quoted-string characters', function () {
+    $parameters = MimeParameterParser::parse([
+        'filename' => 'invoice "draft"\\document.pdf',
+    ]);
+
+    expect($parameters)->toBe([
+        'filename' => 'invoice "draft"\\document.pdf',
+    ]);
+});


### PR DESCRIPTION
Closes #169

This PR fixes attachment filenames that are split across multiple RFC 2231 MIME parameters in IMAP `BODYSTRUCTURE` responses.

Some IMAP servers return attachment filenames as numbered parameters:

```text
filename*0=attachment_name_part_0
filename*1=attachment_name_part_1.pdf
```

ImapEngine previously looked only for an exact `filename` or `name` parameter. As a result, lazy-loaded attachments could have a `null` filename even though the complete filename was present in the response.

Extended parameters containing percent-encoded values and charset information were also not being decoded.

