### PR TITLE
Fix parsing IMAP responses containing 8-bit bytes

### DIFF
--- a/src/Connection/ImapTokenizer.php
+++ b/src/Connection/ImapTokenizer.php
@@ -363,7 +363,7 @@ class ImapTokenizer
     /**
      * Reads an atom token.
      *
-     * ATOMs are sequences of printable ASCII characters that do not contain delimiters.
+     * ATOMs are sequences of non-control characters that do not contain delimiters.
      */
     protected function readAtom(): Atom
     {
@@ -496,20 +496,16 @@ class ImapTokenizer
      */
     protected function isValidAtomCharacter(string $char): bool
     {
-        // Get the ASCII code.
         $code = ord($char);
 
-        // Allow only printable ASCII (32-126).
-        if ($code < 32 || $code > 126) {
+        // Reject control characters and DEL while tolerating the
+        // 8-bit response text returned by some IMAP servers.
+        if ($code < 0x20 || $code === 0x7F) {
             return false;
         }
 
         // Delimiters are not allowed inside ATOMs.
-        if ($this->isDelimiter($char)) {
-            return false;
-        }
-
-        return true;
+        return ! $this->isDelimiter($char);
     }
 
     /**

--- a/tests/Unit/Connection/ImapParserTest.php
+++ b/tests/Unit/Connection/ImapParserTest.php
@@ -149,6 +149,22 @@ test('parses a several lines', function () {
     expect((string) $response5)->toBe('TAG2 OK FETCH completed');
 });
 
+test('parses tagged response text containing 8-bit bytes', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feedRaw("TAG2 NO DELETE failed. No such folder : Missing_\xE0\xE8\xEC\r\n");
+
+    $tokenizer = new ImapTokenizer($stream);
+    $parser = new ImapParser($tokenizer);
+
+    $response = $parser->next();
+
+    expect($response)->toBeInstanceOf(TaggedResponse::class);
+    expect($response->failed())->toBeTrue();
+    expect((string) $response)->toBe("TAG2 NO DELETE failed. No such folder : Missing_\xE0\xE8\xEC");
+});
+
 test('parses list response', function () {
     $stream = new FakeStream;
     $stream->open();

--- a/tests/Unit/Connection/ImapTokenizerTest.php
+++ b/tests/Unit/Connection/ImapTokenizerTest.php
@@ -207,11 +207,11 @@ test('tokenizer throws exception for CR not followed by LF', function () {
     $tokenizer->nextToken();
 })->throws(ImapParserException::class);
 
-test('tokenizer throws exception for an unexpected byte instead of returning an empty atom', function () {
+test('tokenizer throws exception for an unexpected control byte instead of returning an empty atom', function () {
     $stream = new FakeStream;
     $stream->open();
 
-    $stream->feedRaw("TAG1 OK L\x80GIN completed\r\n");
+    $stream->feedRaw("TAG1 OK L\x01GIN completed\r\n");
 
     $tokenizer = new ImapTokenizer($stream);
 
@@ -220,7 +220,7 @@ test('tokenizer throws exception for an unexpected byte instead of returning an 
     expect($tokenizer->nextToken()->value)->toBe('L');
 
     $tokenizer->nextToken();
-})->throws(ImapParserException::class, 'Unexpected byte 0x80 in response at buffer offset 9');
+})->throws(ImapParserException::class, 'Unexpected byte 0x01 in response at buffer offset 9');
 
 test('tokenizer throws exception for an unexpected atom delimiter', function (string $delimiter, string $hex) {
     $stream = new FakeStream;


### PR DESCRIPTION
Closes #175

This PR fixes the tokenizer throwing an exception when an IMAP server includes 8-bit bytes in human-readable response text.

The tokenizer previously accepted only printable ASCII characters inside ATOMs. As a result, responses containing raw bytes from mailbox names would stop at the first 8-bit byte and leave the rest of the response unread.

ATOMs now reject only control bytes and DEL while continuing to split on the existing delimiters. This allows the complete response to be consumed while preserving the protection against invalid control bytes added in #172.