### PR TITLE
Wait for continuation responses before sending literal data

### DIFF
--- a/src/Connection/ImapCommand.php
+++ b/src/Connection/ImapCommand.php
@@ -63,11 +63,14 @@ class ImapCommand implements Stringable
 
         foreach ($this->tokens as $token) {
             if (is_array($token)) {
-                [$lengthDeclaration, $literal] = $token;
+                // For tokens provided as arrays, the first element is a placeholder
+                // (for example, "{20}") that signals a literal value will follow.
+                // The second element holds the actual literal content.
+                [$length, $literal] = $token;
 
                 $lines[] = new ImapCommandLine(
-                    value: "{$line} {$lengthDeclaration}",
-                    synchronizing: ! str_contains($lengthDeclaration, '+'),
+                    value: "{$line} {$length}",
+                    synchronizing: ! str_contains($length, '+'),
                 );
 
                 $line = $literal;

--- a/src/Connection/ImapCommand.php
+++ b/src/Connection/ImapCommand.php
@@ -9,7 +9,7 @@ class ImapCommand implements Stringable
     /**
      * The compiled command lines.
      *
-     * @var string[]
+     * @var ImapCommandLine[]|null
      */
     protected ?array $compiled = null;
 
@@ -49,7 +49,7 @@ class ImapCommand implements Stringable
     /**
      * Compile the command into lines for transmission.
      *
-     * @return string[]
+     * @return ImapCommandLine[]
      */
     public function compile(): array
     {
@@ -63,12 +63,12 @@ class ImapCommand implements Stringable
 
         foreach ($this->tokens as $token) {
             if (is_array($token)) {
-                // For tokens provided as arrays, the first element is a placeholder
-                // (for example, "{20}") that signals a literal value will follow.
-                // The second element holds the actual literal content.
-                [$placeholder, $literal] = $token;
+                [$lengthDeclaration, $literal] = $token;
 
-                $lines[] = "{$line} {$placeholder}";
+                $lines[] = new ImapCommandLine(
+                    value: "{$line} {$lengthDeclaration}",
+                    synchronizing: ! str_contains($lengthDeclaration, '+'),
+                );
 
                 $line = $literal;
             } else {
@@ -76,7 +76,7 @@ class ImapCommand implements Stringable
             }
         }
 
-        $lines[] = $line;
+        $lines[] = new ImapCommandLine($line);
 
         return $this->compiled = $lines;
     }

--- a/src/Connection/ImapCommandLine.php
+++ b/src/Connection/ImapCommandLine.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DirectoryTree\ImapEngine\Connection;
+
+use Stringable;
+
+class ImapCommandLine implements Stringable
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        public string $value,
+        public bool $synchronizing = false,
+    ) {}
+
+    /**
+     * Get the command line as a string.
+     */
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Connection/ImapConnection.php
+++ b/src/Connection/ImapConnection.php
@@ -633,7 +633,11 @@ class ImapConnection implements ConnectionInterface
         $this->setResult(new Result($command));
 
         foreach ($command->compile() as $line) {
-            $this->write($line);
+            $this->write($line->value);
+
+            if ($line->synchronizing) {
+                $this->assertContinuationResponse($command);
+            }
         }
     }
 
@@ -737,6 +741,23 @@ class ImapConnection implements ConnectionInterface
         );
 
         return $response;
+    }
+
+    /**
+     * Assert the server is ready to receive literal data.
+     */
+    protected function assertContinuationResponse(ImapCommand $command): void
+    {
+        $this->assertNextResponse(
+            fn (Response $response) => (
+                $response instanceof ContinuationResponse || (
+                    $response instanceof TaggedResponse
+                    && $response->tag()->is($command->tag())
+                )
+            ),
+            fn (Response $response) => $response instanceof ContinuationResponse,
+            fn (Response $response) => ImapCommandException::make($command, $response),
+        );
     }
 
     /**

--- a/src/Connection/Streams/FakeStream.php
+++ b/src/Connection/Streams/FakeStream.php
@@ -229,4 +229,14 @@ class FakeStream implements StreamInterface
 
         Assert::assertTrue($found, "Failed asserting that the string '{$string}' was written to the stream.");
     }
+
+    /**
+     * Assert that the given data was not written to the stream.
+     */
+    public function assertNotWritten(string $string): void
+    {
+        foreach ($this->written as $written) {
+            Assert::assertStringNotContainsString($string, $written);
+        }
+    }
 }

--- a/tests/Unit/Connection/ImapCommandTest.php
+++ b/tests/Unit/Connection/ImapCommandTest.php
@@ -1,23 +1,35 @@
 <?php
 
 use DirectoryTree\ImapEngine\Connection\ImapCommand;
+use DirectoryTree\ImapEngine\Connection\ImapCommandLine;
 
 test('compile returns correct command lines for no tokens', function () {
     $cmd = new ImapCommand('A001', 'NOOP');
 
-    expect($cmd->compile())->toEqual(['A001 NOOP']);
+    $lines = $cmd->compile();
+
+    expect($lines)->toHaveCount(1);
+    expect($lines[0])->toBeInstanceOf(ImapCommandLine::class);
+    expect((string) $lines[0])->toBe('A001 NOOP');
+    expect($lines[0]->synchronizing)->toBeFalse();
 });
 
 test('compile returns correct command lines for string tokens', function () {
     $cmd = new ImapCommand('A002', 'LOGIN', ['user', 'pass']);
 
-    expect($cmd->compile())->toEqual(['A002 LOGIN user pass']);
+    $lines = $cmd->compile();
+
+    expect($lines)->toHaveCount(1);
+    expect((string) $lines[0])->toBe('A002 LOGIN user pass');
 });
 
 test('redacted returns command lines with tokens redacted for safety', function () {
     $cmd = new ImapCommand('A002', 'LOGIN', ['user', 'pass']);
 
-    expect($cmd->redacted()->compile())->toEqual(['A002 LOGIN [redacted] [redacted]']);
+    $lines = $cmd->redacted()->compile();
+
+    expect($lines)->toHaveCount(1);
+    expect((string) $lines[0])->toBe('A002 LOGIN [redacted] [redacted]');
 });
 
 test('compile returns correct command lines with a literal token', function () {
@@ -25,7 +37,26 @@ test('compile returns correct command lines with a literal token', function () {
         ['{20}', 'literal-data'],
     ]);
 
-    expect($cmd->compile())->toEqual(['A003 APPEND "INBOX" {20}', 'literal-data']);
+    $lines = $cmd->compile();
+
+    expect($lines)->toHaveCount(2);
+    expect((string) $lines[0])->toBe('A003 APPEND "INBOX" {20}');
+    expect($lines[0]->synchronizing)->toBeTrue();
+    expect((string) $lines[1])->toBe('literal-data');
+    expect($lines[1]->synchronizing)->toBeFalse();
+});
+
+test('compile marks non-synchronizing literal command lines', function () {
+    $cmd = new ImapCommand('A003', 'APPEND "INBOX"', [
+        ['{20+}', 'literal-data'],
+    ]);
+
+    $lines = $cmd->compile();
+
+    expect($lines)->toHaveCount(2);
+    expect((string) $lines[0])->toBe('A003 APPEND "INBOX" {20+}');
+    expect($lines[0]->synchronizing)->toBeFalse();
+    expect((string) $lines[1])->toBe('literal-data');
 });
 
 test('compile returns correct command lines with multiple tokens including a literal', function () {
@@ -35,10 +66,29 @@ test('compile returns correct command lines with multiple tokens including a lit
         'TOKEN2',
     ]);
 
-    expect($cmd->compile())->toEqual([
-        'A004 COMMAND TOKEN1 {5}',
-        'LIT TOKEN2',
+    $lines = $cmd->compile();
+
+    expect($lines)->toHaveCount(2);
+    expect((string) $lines[0])->toBe('A004 COMMAND TOKEN1 {5}');
+    expect($lines[0]->synchronizing)->toBeTrue();
+    expect((string) $lines[1])->toBe('LIT TOKEN2');
+});
+
+test('compile tracks synchronization for each literal command line', function () {
+    $cmd = new ImapCommand('A004', 'COMMAND', [
+        ['{5+}', 'FIRST'],
+        ['{6}', 'SECOND'],
     ]);
+
+    $lines = $cmd->compile();
+
+    expect($lines)->toHaveCount(3);
+    expect((string) $lines[0])->toBe('A004 COMMAND {5+}');
+    expect($lines[0]->synchronizing)->toBeFalse();
+    expect((string) $lines[1])->toBe('FIRST {6}');
+    expect($lines[1]->synchronizing)->toBeTrue();
+    expect((string) $lines[2])->toBe('SECOND');
+    expect($lines[2]->synchronizing)->toBeFalse();
 });
 
 test('to string returns the command lines joined by CRLF', function () {

--- a/tests/Unit/Connection/ImapConnectionTest.php
+++ b/tests/Unit/Connection/ImapConnectionTest.php
@@ -391,6 +391,66 @@ test('append message', function () {
     $stream->assertWritten('TAG1 APPEND "INBOX" (\Seen) "Test message"');
 });
 
+test('append sends literal data after receiving a continuation response', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        '+ Ready for literal data',
+        'TAG1 OK APPEND completed',
+    ]);
+
+    $connection = new ImapConnection($stream);
+    $connection->connect('imap.example.com');
+
+    $message = "Subject: probe\r\n\r\nbody";
+
+    $connection->append('INBOX', $message);
+
+    $stream->assertWritten('TAG1 APPEND "INBOX" {22}');
+    $stream->assertWritten($message);
+});
+
+test('append does not send literal data when the server rejects the command', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 NO [TRYCREATE] No such mailbox',
+    ]);
+
+    $connection = new ImapConnection($stream);
+    $connection->connect('imap.example.com');
+
+    $message = "Subject: probe\r\n\r\nbody";
+
+    expect(fn () => $connection->append('Missing', $message))
+        ->toThrow(ImapCommandException::class);
+
+    $stream->assertWritten('TAG1 APPEND "Missing" {22}');
+    $stream->assertNotWritten($message);
+});
+
+test('send does not wait before sending non-synchronizing literal data', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed('* OK Welcome to IMAP');
+
+    $connection = new ImapConnection($stream);
+    $connection->connect('imap.example.com');
+
+    $connection->send('APPEND', [
+        '"INBOX"',
+        ['{4+}', 'test'],
+    ]);
+
+    $stream->assertWritten('TAG1 APPEND "INBOX" {4+}');
+    $stream->assertWritten('test');
+});
+
 test('copy messages', function () {
     $stream = new FakeStream;
     $stream->open();


### PR DESCRIPTION
Closes #174

This PR fixes literal data being written to the IMAP server before it sends a continuation response.

ImapEngine previously compiled a command and wrote every line immediately. For commands such as `APPEND`, this meant the message contents were sent directly after the `{n}` length declaration even though `{n}` tells the server the client will wait for `+`.

Compiled command lines now indicate whether they contain a synchronizing literal declaration. The connection writes the declaration, waits for the continuation response, and only then writes the literal data. If the server rejects the command, the message contents remain unsent and the connection stays synchronized.

Non-synchronizing `{n+}` literals are also represented so they can be sent without waiting when support is added in the future.