### PR TITLE
Improve APPEND results and safely expunge specific messages

### DIFF
--- a/src/AppendResult.php
+++ b/src/AppendResult.php
@@ -6,6 +6,9 @@ use DirectoryTree\ImapEngine\Connection\Responses\Data\ResponseCodeData;
 use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 
+/**
+ * @see https://datatracker.ietf.org/doc/html/rfc4315#section-3
+ */
 class AppendResult
 {
     /**

--- a/src/AppendResult.php
+++ b/src/AppendResult.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace DirectoryTree\ImapEngine;
+
+use DirectoryTree\ImapEngine\Connection\Responses\Data\ResponseCodeData;
+use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
+use DirectoryTree\ImapEngine\Connection\Tokens\Token;
+
+class AppendResult
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        protected ?int $uidValidity = null,
+        protected ?int $uid = null,
+    ) {}
+
+    /**
+     * Create an append result from the tagged response.
+     */
+    public static function fromResponse(TaggedResponse $response): static
+    {
+        $data = $response->tokenAt(2);
+
+        if (! $data instanceof ResponseCodeData) {
+            return new static;
+        }
+
+        $code = $data->first();
+
+        if (! $code instanceof Token || ! $code->is('APPENDUID')) {
+            return new static;
+        }
+
+        return new static(
+            uidValidity: (int) $data->tokenAt(1)->value,
+            uid: (int) $data->tokenAt(2)->value,
+        );
+    }
+
+    /**
+     * Get the mailbox UID validity value.
+     */
+    public function uidValidity(): ?int
+    {
+        return $this->uidValidity;
+    }
+
+    /**
+     * Get the appended message UID.
+     */
+    public function uid(): ?int
+    {
+        return $this->uid;
+    }
+}

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -2,6 +2,8 @@
 
 namespace DirectoryTree\ImapEngine\Connection;
 
+use DateTimeInterface;
+use DirectoryTree\ImapEngine\AppendResult;
 use DirectoryTree\ImapEngine\Collections\ResponseCollection;
 use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
@@ -92,7 +94,7 @@ interface ConnectionInterface
      *
      * @see https://datatracker.ietf.org/doc/html/rfc9051#name-expunge-command
      */
-    public function expunge(): ResponseCollection;
+    public function expunge(array|int|null $uids = null): ResponseCollection;
 
     /**
      * Send a "CAPABILITY" command.
@@ -259,7 +261,7 @@ interface ConnectionInterface
      *
      * @see https://datatracker.ietf.org/doc/html/rfc9051#name-append-command
      */
-    public function append(string $folder, string $message, ?array $flags = null): TaggedResponse;
+    public function append(string $folder, string $message, ?array $flags = null, ?DateTimeInterface $date = null): AppendResult;
 
     /**
      * Send a "UID COPY" command.

--- a/src/Connection/ImapConnection.php
+++ b/src/Connection/ImapConnection.php
@@ -2,6 +2,8 @@
 
 namespace DirectoryTree\ImapEngine\Connection;
 
+use DateTimeInterface;
+use DirectoryTree\ImapEngine\AppendResult;
 use DirectoryTree\ImapEngine\Collections\ResponseCollection;
 use DirectoryTree\ImapEngine\Connection\Loggers\LoggerInterface;
 use DirectoryTree\ImapEngine\Connection\Responses\ContinuationResponse;
@@ -363,7 +365,7 @@ class ImapConnection implements ConnectionInterface
     /**
      * {@inheritDoc}
      */
-    public function append(string $folder, string $message, ?array $flags = null): TaggedResponse
+    public function append(string $folder, string $message, ?array $flags = null, ?DateTimeInterface $date = null): AppendResult
     {
         $tokens = [];
 
@@ -373,11 +375,17 @@ class ImapConnection implements ConnectionInterface
             $tokens[] = Str::list($flags);
         }
 
+        if ($date) {
+            $tokens[] = Str::literal($date->format('d-M-Y H:i:s O'));
+        }
+
         $tokens[] = Str::literal($message);
 
         $this->send('APPEND', $tokens, tag: $tag);
 
-        return $this->assertTaggedResponse($tag);
+        return AppendResult::fromResponse(
+            $this->assertTaggedResponse($tag)
+        );
     }
 
     /**
@@ -557,9 +565,13 @@ class ImapConnection implements ConnectionInterface
     /**
      * {@inheritDoc}
      */
-    public function expunge(): ResponseCollection
+    public function expunge(array|int|null $uids = null): ResponseCollection
     {
-        $this->send('EXPUNGE', tag: $tag);
+        $this->send(
+            $uids === null ? 'EXPUNGE' : 'UID EXPUNGE',
+            $uids === null ? [] : [Str::set($uids)],
+            $tag,
+        );
 
         $this->assertTaggedResponse($tag);
 

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -241,9 +241,9 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
     /**
      * {@inheritDoc}
      */
-    public function expunge(): array
+    public function expunge(array|int|null $uids = null): array
     {
-        return $this->mailbox->connection()->expunge()->map(
+        return $this->mailbox->connection()->expunge($uids)->map(
             fn (UntaggedResponse $response) => $response->tokenAt(1)->value
         )->all();
     }

--- a/src/FolderInterface.php
+++ b/src/FolderInterface.php
@@ -79,7 +79,7 @@ interface FolderInterface
     /**
      * Expunge the mailbox and return the expunged message sequence numbers.
      */
-    public function expunge(): array;
+    public function expunge(array|int|null $uids = null): array;
 
     /**
      * Delete the current folder.

--- a/src/Message.php
+++ b/src/Message.php
@@ -171,7 +171,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
             ->store($flag, $this->uid, mode: $operation);
 
         if ($expunge) {
-            $this->folder->expunge();
+            $this->folder->expunge($this->uid);
         }
 
         $this->flags = match ($operation) {
@@ -214,10 +214,6 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
         switch (true) {
             case in_array('MOVE', $capabilities):
                 $response = $mailbox->connection()->move($folder, $this->uid);
-
-                if ($expunge) {
-                    $this->folder->expunge();
-                }
 
                 return MessageResponseParser::getUidFromCopy($response);
 

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -3,6 +3,7 @@
 namespace DirectoryTree\ImapEngine;
 
 use BackedEnum;
+use DateTimeInterface;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Collections\ResponseCollection;
 use DirectoryTree\ImapEngine\Connection\ConnectionInterface;
@@ -74,16 +75,11 @@ class MessageQuery implements MessageQueryInterface
     /**
      * Append a new message to the folder.
      */
-    public function append(string $message, mixed $flags = null): int
+    public function append(string $message, mixed $flags = null, ?DateTimeInterface $date = null): AppendResult
     {
-        $response = $this->connection()->append(
-            $this->folder->path(), $message, (array) Str::enums($flags),
+        return $this->connection()->append(
+            $this->folder->path(), $message, (array) Str::enums($flags), $date,
         );
-
-        return (int) $response // TAG4 OK [APPENDUID <uidvalidity> <uid>] APPEND completed.
-            ->tokenAt(2) // [APPENDUID <uidvalidity> <uid>]
-            ->tokenAt(2) // <uid>
-            ->value;
     }
 
     /**
@@ -209,7 +205,7 @@ class MessageQuery implements MessageQueryInterface
             ->store([ImapFlag::Deleted->value], $uids, mode: '+');
 
         if ($expunge) {
-            $this->folder->expunge();
+            $this->folder->expunge($uids);
         }
     }
 
@@ -231,7 +227,7 @@ class MessageQuery implements MessageQueryInterface
         );
 
         if ($expunge) {
-            $this->folder->expunge();
+            $this->folder->expunge($uids);
         }
 
         return count($uids);
@@ -289,10 +285,6 @@ class MessageQuery implements MessageQueryInterface
         }
 
         $this->connection()->move($folder, $uids);
-
-        if ($expunge) {
-            $this->folder->expunge();
-        }
 
         return count($uids);
     }

--- a/src/MessageQueryInterface.php
+++ b/src/MessageQueryInterface.php
@@ -3,6 +3,7 @@
 namespace DirectoryTree\ImapEngine;
 
 use BackedEnum;
+use DateTimeInterface;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
@@ -207,7 +208,7 @@ interface MessageQueryInterface
     /**
      * Append a new message to the folder.
      */
-    public function append(string $message, mixed $flags = null): int;
+    public function append(string $message, mixed $flags = null, ?DateTimeInterface $date = null): AppendResult;
 
     /**
      * Execute a callback over each message via a chunked query.

--- a/src/Testing/FakeFolder.php
+++ b/src/Testing/FakeFolder.php
@@ -141,7 +141,7 @@ class FakeFolder implements FolderInterface
     /**
      * {@inheritDoc}
      */
-    public function expunge(): array
+    public function expunge(array|int|null $uids = null): array
     {
         return [];
     }

--- a/src/Testing/FakeMessageQuery.php
+++ b/src/Testing/FakeMessageQuery.php
@@ -3,6 +3,8 @@
 namespace DirectoryTree\ImapEngine\Testing;
 
 use BackedEnum;
+use DateTimeInterface;
+use DirectoryTree\ImapEngine\AppendResult;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
@@ -62,7 +64,7 @@ class FakeMessageQuery implements MessageQueryInterface
     /**
      * {@inheritDoc}
      */
-    public function append(string $message, mixed $flags = null): int
+    public function append(string $message, mixed $flags = null, ?DateTimeInterface $date = null): AppendResult
     {
         $uid = 1;
 
@@ -74,7 +76,7 @@ class FakeMessageQuery implements MessageQueryInterface
             new FakeMessage($uid, $flags === null ? [] : $flags, $message)
         );
 
-        return $uid;
+        return new AppendResult(uid: $uid);
     }
 
     /**

--- a/tests/Integration/MessagesTest.php
+++ b/tests/Integration/MessagesTest.php
@@ -51,7 +51,7 @@ test('first', function () {
 
     $uid = $folder->messages()->append(
         new DraftMessage(from: 'foo@example.com', text: 'hello world'),
-    );
+    )->uid();
 
     expect($folder->messages()->first()->uid())->toBe($uid);
 });
@@ -61,7 +61,7 @@ test('first or fail', function () {
 
     $uid = $folder->messages()->append(
         new DraftMessage(from: 'foo@example.com', text: 'hello world'),
-    );
+    )->uid();
 
     $message = $folder->messages()->firstOrFail();
 
@@ -82,7 +82,7 @@ test('find', function () {
             from: 'foo@email.com',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     $message = $folder->messages()->find($uid);
 
@@ -97,7 +97,7 @@ test('find or fail', function () {
             from: 'foo@email.com',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     $message = $folder->messages()->findOrFail($uid);
 
@@ -118,7 +118,7 @@ test('get without fetches', function () {
             from: 'foo@email.com',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     $messages = $folder->messages()->get();
 
@@ -134,7 +134,7 @@ test('get with fetches', function (callable $callback) {
             from: 'foo@email.com',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     $messages = $callback($folder->messages())->get();
 
@@ -157,7 +157,7 @@ test('get with size', function () {
             subject: 'Test Subject',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     // Fetch without size - should be null
     $messagesWithoutSize = $folder->messages()->get();
@@ -185,8 +185,8 @@ test('size reflects actual message size', function () {
         text: str_repeat('This is a longer message with more content. ', 100),
     );
 
-    $uid1 = $folder->messages()->append($shortMessage);
-    $uid2 = $folder->messages()->append($longMessage);
+    $uid1 = $folder->messages()->append($shortMessage)->uid();
+    $uid2 = $folder->messages()->append($longMessage)->uid();
 
     $messages = $folder->messages()->withSize()->get();
 
@@ -216,7 +216,7 @@ test('append', function () {
             date: $datetime = Carbon::now()->subYear(),
         ),
         ['\\Seen'],
-    );
+    )->uid();
 
     $message = $messages
         ->withHeaders()
@@ -246,7 +246,7 @@ test('flag', function () {
             from: 'foo@email.com',
             text: 'flag test'
         )
-    );
+    )->uid();
 
     // Initially, message should not be marked as seen.
     $message = $messages->withFlags()->find($uid);
@@ -273,7 +273,7 @@ test('copy', function () {
             from: 'foo@email.com',
             text: 'copy test'
         )
-    );
+    )->uid();
 
     $message = $messages->withHeaders()->withBody()->find($uid);
 
@@ -305,7 +305,7 @@ test('move', function () {
             from: 'foo@email.com',
             text: 'move test'
         )
-    );
+    )->uid();
 
     $message = $messages->withHeaders()->withBody()->find($uid);
 
@@ -338,7 +338,7 @@ test('delete', function () {
             from: 'foo@email.com',
             text: 'delete test'
         )
-    );
+    )->uid();
 
     $message = $messages->find($uid);
 
@@ -355,14 +355,14 @@ test('retrieves messages using or statement', function () {
             from: 'foo@email.com',
             text: $firstUuid = uniqid(),
         ),
-    );
+    )->uid();
 
     $secondUid = $folder->messages()->append(
         new DraftMessage(
             from: 'foo@email.com',
             text: $secondUuid = uniqid(),
         ),
-    );
+    )->uid();
 
     $results = $folder->messages()
         ->where(fn (ImapQueryBuilder $q) => $q->body($firstUuid))
@@ -383,7 +383,7 @@ test('retrieves messages by flag', function (string $flag, string $criteria) {
             text: 'hello world',
         ),
         [$flag],
-    );
+    )->uid();
 
     expect(
         $folder->messages()
@@ -415,7 +415,7 @@ test('marks messages as read when fetching', function () {
             from: 'foo@email.com',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     $folder->messages()
         ->markAsRead()
@@ -435,7 +435,7 @@ test('leaves messages unread when fetching', function () {
             from: 'foo@email.com',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     $folder->messages()
         ->leaveUnread()
@@ -455,7 +455,7 @@ test('querying for unseen messages', function () {
             from: 'foo@email.com',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     expect($folder->messages()->unseen()->count())->toBe(1);
 
@@ -473,7 +473,7 @@ test('sort by subject', function () {
             subject: 'AAA First alphabetically',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     $uid2 = $folder->messages()->append(
         new DraftMessage(
@@ -481,7 +481,7 @@ test('sort by subject', function () {
             subject: 'ZZZ Last alphabetically',
             text: 'hello world',
         ),
-    );
+    )->uid();
 
     // Ascending order: AAA should come before ZZZ
     $messagesAsc = $folder->messages()->sortBy('subject', 'asc')->get();

--- a/tests/Unit/AppendResultTest.php
+++ b/tests/Unit/AppendResultTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use DirectoryTree\ImapEngine\AppendResult;
+use DirectoryTree\ImapEngine\Connection\Responses\Data\ResponseCodeData;
+use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
+use DirectoryTree\ImapEngine\Connection\Tokens\Atom;
+
+test('it creates a result from an APPENDUID response', function () {
+    $response = new TaggedResponse([
+        new Atom('TAG1'),
+        new Atom('OK'),
+        new ResponseCodeData([
+            new Atom('APPENDUID'),
+            new Atom('1234567890'),
+            new Atom('42'),
+        ]),
+        new Atom('APPEND completed'),
+    ]);
+
+    $result = AppendResult::fromResponse($response);
+
+    expect($result->uidValidity())->toBe(1234567890)
+        ->and($result->uid())->toBe(42);
+});
+
+test('it creates a result without identifiers when APPENDUID is unavailable', function () {
+    $response = new TaggedResponse([
+        new Atom('TAG1'),
+        new Atom('OK'),
+        new Atom('APPEND completed'),
+    ]);
+
+    $result = AppendResult::fromResponse($response);
+
+    expect($result->uidValidity())->toBeNull()
+        ->and($result->uid())->toBeNull();
+});

--- a/tests/Unit/Connection/ImapConnectionTest.php
+++ b/tests/Unit/Connection/ImapConnectionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use DirectoryTree\ImapEngine\AppendResult;
 use DirectoryTree\ImapEngine\Collections\ResponseCollection;
 use DirectoryTree\ImapEngine\Connection\ImapConnection;
 use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
@@ -380,15 +381,44 @@ test('append message', function () {
 
     $stream->feed([
         '* OK Welcome to IMAP',
+        'TAG1 OK [APPENDUID 1234567890 42] APPEND completed',
+    ]);
+
+    $connection = new ImapConnection($stream);
+    $connection->connect('imap.example.com');
+
+    $result = $connection->append('INBOX', 'Test message', ['\\Seen']);
+
+    $stream->assertWritten('TAG1 APPEND "INBOX" (\Seen) "Test message"');
+
+    expect($result)->toBeInstanceOf(AppendResult::class)
+        ->and($result->uidValidity())->toBe(1234567890)
+        ->and($result->uid())->toBe(42);
+});
+
+test('append message with internal date', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
         'TAG1 OK APPEND completed',
     ]);
 
     $connection = new ImapConnection($stream);
     $connection->connect('imap.example.com');
 
-    $connection->append('INBOX', 'Test message', ['\\Seen']);
+    $result = $connection->append(
+        'INBOX',
+        'Test message',
+        ['\\Seen'],
+        new DateTimeImmutable('2026-09-01 12:34:56 -04:00'),
+    );
 
-    $stream->assertWritten('TAG1 APPEND "INBOX" (\Seen) "Test message"');
+    $stream->assertWritten('TAG1 APPEND "INBOX" (\Seen) "01-Sep-2026 12:34:56 -0400" "Test message"');
+
+    expect($result->uidValidity())->toBeNull()
+        ->and($result->uid())->toBeNull();
 });
 
 test('append sends literal data after receiving a continuation response', function () {
@@ -747,6 +777,26 @@ test('expunge', function () {
     $responses = $connection->expunge();
 
     $stream->assertWritten('TAG1 EXPUNGE');
+
+    expect($responses->count())->toBeGreaterThan(0);
+});
+
+test('expunge messages by uid', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        '* 1 EXPUNGE',
+        'TAG1 OK UID EXPUNGE completed',
+    ]);
+
+    $connection = new ImapConnection($stream);
+    $connection->connect('imap.example.com');
+
+    $responses = $connection->expunge([1, 2, 3]);
+
+    $stream->assertWritten('TAG1 UID EXPUNGE 1:3');
 
     expect($responses->count())->toBeGreaterThan(0);
 });

--- a/tests/Unit/MessageQueryTest.php
+++ b/tests/Unit/MessageQueryTest.php
@@ -78,6 +78,27 @@ test('destroy with multiple messages', function () {
     $stream->assertWritten('TAG2 UID STORE 1:3 +FLAGS.SILENT (\Deleted)');
 });
 
+test('destroy with expunge only expunges the given messages', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        'TAG2 OK UID STORE completed',
+        'TAG3 OK UID EXPUNGE completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+
+    $mailbox->connect(new ImapConnection($stream));
+
+    query($mailbox)->destroy([1, 2, 3], expunge: true);
+
+    $stream->assertWritten('TAG2 UID STORE 1:3 +FLAGS.SILENT (\Deleted)');
+    $stream->assertWritten('TAG3 UID EXPUNGE 1:3');
+});
+
 test('oldest sets fetch order to asc', function () {
     $query = query();
 
@@ -208,9 +229,10 @@ test('append with single flag converts to array', function (mixed $flag) {
     $folder = new Folder($mailbox, 'INBOX');
     $query = new MessageQuery($folder, new ImapQueryBuilder);
 
-    $uid = $query->append('Hello world', $flag);
+    $result = $query->append('Hello world', $flag);
 
-    expect($uid)->toBe(1);
+    expect($result->uidValidity())->toBe(1234567890)
+        ->and($result->uid())->toBe(1);
     $stream->assertWritten('TAG2 APPEND "INBOX" (\\Seen) "Hello world"');
 })->with([ImapFlag::Seen, '\\Seen']);
 
@@ -410,7 +432,7 @@ test('delete with expunge also expunges folder', function () {
         '* SEARCH 1 2',
         'TAG2 OK SEARCH completed',
         'TAG3 OK UID STORE completed',
-        'TAG4 OK EXPUNGE completed',
+        'TAG4 OK UID EXPUNGE completed',
     ]);
 
     $mailbox = Mailbox::make();
@@ -423,7 +445,7 @@ test('delete with expunge also expunges folder', function () {
 
     expect($count)->toBe(2);
     $stream->assertWritten('TAG3 UID STORE 1:2 +FLAGS.SILENT (\Deleted)');
-    $stream->assertWritten('TAG4 EXPUNGE');
+    $stream->assertWritten('TAG4 UID EXPUNGE 1:2');
 });
 
 test('move moves all matching messages to folder', function () {

--- a/tests/Unit/MessageTest.php
+++ b/tests/Unit/MessageTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use DirectoryTree\ImapEngine\Connection\ImapConnection;
+use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
 use DirectoryTree\ImapEngine\Exceptions\ImapCapabilityException;
 use DirectoryTree\ImapEngine\Folder;
@@ -52,6 +53,35 @@ test('it copies and then deletes message using UIDPLUS when incapable of MOVE an
     $newUid = $message->move('INBOX.Sent');
 
     expect($newUid)->toBe(123);
+});
+
+test('it only expunges the deleted message', function () {
+    $mailbox = Mailbox::make([
+        'username' => 'foo',
+        'password' => 'bar',
+    ]);
+
+    $stream = new FakeStream;
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        'TAG2 OK STORE completed',
+        'TAG3 OK UID EXPUNGE completed',
+    ]);
+
+    $connection = new ImapConnection($stream);
+
+    $mailbox->connect($connection);
+
+    $folder = new Folder($mailbox, 'INBOX', [], '/');
+
+    $message = new Message($folder, 42, [], 'header', 'body');
+
+    $message->delete(expunge: true);
+
+    $stream->assertWritten('TAG2 UID STORE 42 +FLAGS.SILENT (\Deleted)');
+    $stream->assertWritten('TAG3 UID EXPUNGE 42');
 });
 
 test('it throws exception when server does not support MOVE or UIDPLUS capabilities', function () {

--- a/tests/Unit/Testing/FakeMessageQueryTest.php
+++ b/tests/Unit/Testing/FakeMessageQueryTest.php
@@ -74,14 +74,14 @@ test('it auto-increments uid when appending messages', function () {
     $folder = new FakeFolder('INBOX');
     $query = new FakeMessageQuery($folder);
 
-    $uid1 = $query->append('First message');
-    expect($uid1)->toBe(1);
+    $result1 = $query->append('First message');
+    expect($result1->uid())->toBe(1);
 
-    $uid2 = $query->append('Second message');
-    expect($uid2)->toBe(2);
+    $result2 = $query->append('Second message');
+    expect($result2->uid())->toBe(2);
 
-    $uid3 = $query->append('Third message');
-    expect($uid3)->toBe(3);
+    $result3 = $query->append('Third message');
+    expect($result3->uid())->toBe(3);
 
     expect($query->count())->toBe(3);
 });
@@ -93,8 +93,8 @@ test('it continues auto-incrementing from last message uid', function () {
 
     $query = new FakeMessageQuery($folder);
 
-    $uid = $query->append('New message');
-    expect($uid)->toBe(6);
+    $result = $query->append('New message');
+    expect($result->uid())->toBe(6);
 });
 
 test('it can find message by uid', function () {


### PR DESCRIPTION
IMAP servers can successfully append a message without returning APPENDUID when UIDPLUS is unavailable. The current append API assumes that response is always present and returns only an integer UID, which prevents callers from handling a successful append without identifiers. It also does not allow the optional APPEND internal date to be supplied.

Deleting a specific message with expunge enabled currently follows the flag update with a mailbox-wide EXPUNGE. That can permanently remove other messages which were already marked as deleted by another client.

This introduces an AppendResult containing nullable UID validity and UID values, adds optional internal-date support to APPEND, and allows expunge operations to target exact UIDs through UID EXPUNGE. Message and query deletion now use their known UIDs, while MOVE no longer performs a redundant mailbox-wide expunge after the server has already removed the source messages.

This targets v2.0 because changing append from an integer or tagged response to AppendResult is a breaking API change.