### PR TITLE
Simplify message ordering and server-side sorting

### DIFF
--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -8,7 +8,7 @@ use DirectoryTree\ImapEngine\Collections\ResponseCollection;
 use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
-use DirectoryTree\ImapEngine\SortCriterion;
+use DirectoryTree\ImapEngine\ImapSort;
 use Generator;
 
 interface ConnectionInterface
@@ -119,11 +119,9 @@ interface ConnectionInterface
      *
      * Execute a sort request using RFC 5256.
      *
-     * @param  array<int, SortCriterion>  $criteria
-     *
      * @see https://datatracker.ietf.org/doc/html/rfc5256
      */
-    public function sort(array $criteria, array $params): UntaggedResponse;
+    public function sort(ImapSort $sort, array $params): UntaggedResponse;
 
     /**
      * Send a "FETCH" command.

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -8,7 +8,7 @@ use DirectoryTree\ImapEngine\Collections\ResponseCollection;
 use DirectoryTree\ImapEngine\Connection\Responses\TaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
-use DirectoryTree\ImapEngine\Enums\ImapSortKey;
+use DirectoryTree\ImapEngine\SortCriterion;
 use Generator;
 
 interface ConnectionInterface
@@ -119,9 +119,11 @@ interface ConnectionInterface
      *
      * Execute a sort request using RFC 5256.
      *
+     * @param  array<int, SortCriterion>  $criteria
+     *
      * @see https://datatracker.ietf.org/doc/html/rfc5256
      */
-    public function sort(ImapSortKey $key, string $direction, array $params): UntaggedResponse;
+    public function sort(array $criteria, array $params): UntaggedResponse;
 
     /**
      * Send a "FETCH" command.

--- a/src/Connection/ImapConnection.php
+++ b/src/Connection/ImapConnection.php
@@ -22,7 +22,7 @@ use DirectoryTree\ImapEngine\Exceptions\ImapConnectionFailedException;
 use DirectoryTree\ImapEngine\Exceptions\ImapConnectionTimedOutException;
 use DirectoryTree\ImapEngine\Exceptions\ImapResponseException;
 use DirectoryTree\ImapEngine\Exceptions\ImapStreamException;
-use DirectoryTree\ImapEngine\SortCriterion;
+use DirectoryTree\ImapEngine\ImapSort;
 use DirectoryTree\ImapEngine\Support\Str;
 use Exception;
 use Generator;
@@ -509,14 +509,9 @@ class ImapConnection implements ConnectionInterface
     /**
      * {@inheritDoc}
      */
-    public function sort(array $criteria, array $params): UntaggedResponse
+    public function sort(ImapSort $sort, array $params): UntaggedResponse
     {
-        $sortCriteria = implode(' ', array_map(
-            fn (SortCriterion $criterion) => $criterion->toImap(),
-            $criteria,
-        ));
-
-        $this->send('UID SORT', ["({$sortCriteria})", 'UTF-8', ...$params], tag: $tag);
+        $this->send('UID SORT', ["({$sort->toImap()})", 'UTF-8', ...$params], tag: $tag);
 
         $this->assertTaggedResponse($tag);
 

--- a/src/Connection/ImapConnection.php
+++ b/src/Connection/ImapConnection.php
@@ -16,13 +16,13 @@ use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
 use DirectoryTree\ImapEngine\Connection\Streams\StreamInterface;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
-use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\Exceptions\ImapCommandException;
 use DirectoryTree\ImapEngine\Exceptions\ImapConnectionClosedException;
 use DirectoryTree\ImapEngine\Exceptions\ImapConnectionFailedException;
 use DirectoryTree\ImapEngine\Exceptions\ImapConnectionTimedOutException;
 use DirectoryTree\ImapEngine\Exceptions\ImapResponseException;
 use DirectoryTree\ImapEngine\Exceptions\ImapStreamException;
+use DirectoryTree\ImapEngine\SortCriterion;
 use DirectoryTree\ImapEngine\Support\Str;
 use Exception;
 use Generator;
@@ -509,9 +509,12 @@ class ImapConnection implements ConnectionInterface
     /**
      * {@inheritDoc}
      */
-    public function sort(ImapSortKey $key, string $direction, array $params): UntaggedResponse
+    public function sort(array $criteria, array $params): UntaggedResponse
     {
-        $sortCriteria = $direction === 'desc' ? "REVERSE {$key->value}" : $key->value;
+        $sortCriteria = implode(' ', array_map(
+            fn (SortCriterion $criterion) => $criterion->toImap(),
+            $criteria,
+        ));
 
         $this->send('UID SORT', ["({$sortCriteria})", 'UTF-8', ...$params], tag: $tag);
 

--- a/src/Enums/SortDirection.php
+++ b/src/Enums/SortDirection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DirectoryTree\ImapEngine\Enums;
+
+enum SortDirection: string
+{
+    case Ascending = 'asc';
+    case Descending = 'desc';
+}

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -95,7 +95,7 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
      */
     public function idle(callable $callback, ?callable $query = null, callable|int $timeout = 300): void
     {
-        if (! in_array('IDLE', $this->mailbox->capabilities())) {
+        if (! $this->mailbox->hasCapability('IDLE')) {
             throw new ImapCapabilityException('Unable to IDLE. IMAP server does not support IDLE capability.');
         }
 
@@ -183,7 +183,7 @@ class Folder implements Arrayable, FolderInterface, JsonSerializable
      */
     public function quota(): array
     {
-        if (! in_array('QUOTA', $this->mailbox->capabilities())) {
+        if (! $this->mailbox->hasCapability('QUOTA')) {
             throw new ImapCapabilityException(
                 'Unable to fetch mailbox quotas. IMAP server does not support QUOTA capability.'
             );

--- a/src/HasCapabilities.php
+++ b/src/HasCapabilities.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DirectoryTree\ImapEngine;
+
+trait HasCapabilities
+{
+    /**
+     * Determine if the mailbox supports the given capability.
+     */
+    public function hasCapability(string $capability): bool
+    {
+        $capability = strtoupper($capability);
+
+        foreach ($this->capabilities() as $supported) {
+            $supported = strtoupper($supported);
+
+            if ($supported === $capability || str_starts_with($supported, "{$capability}=")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/ImapSort.php
+++ b/src/ImapSort.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DirectoryTree\ImapEngine;
+
+class ImapSort
+{
+    /**
+     * @param  array<int, SortCriterion>  $criteria
+     */
+    public function __construct(
+        public array $criteria = [],
+    ) {}
+
+    /**
+     * Add a sort criterion.
+     */
+    public function add(SortCriterion $criterion): static
+    {
+        $this->criteria[] = $criterion;
+
+        return $this;
+    }
+
+    /**
+     * Get the IMAP SORT criteria.
+     */
+    public function toImap(): string
+    {
+        return implode(' ', array_map(
+            fn (SortCriterion $criterion) => $criterion->toImap(),
+            $this->criteria,
+        ));
+    }
+}

--- a/src/ImapSort.php
+++ b/src/ImapSort.php
@@ -5,6 +5,8 @@ namespace DirectoryTree\ImapEngine;
 class ImapSort
 {
     /**
+     * Constructor.
+     *
      * @param  array<int, SortCriterion>  $criteria
      */
     public function __construct(

--- a/src/ImapSort.php
+++ b/src/ImapSort.php
@@ -5,13 +5,19 @@ namespace DirectoryTree\ImapEngine;
 class ImapSort
 {
     /**
-     * Constructor.
+     * The sort criteria.
      *
-     * @param  array<int, SortCriterion>  $criteria
+     * @var array<int, SortCriterion>
      */
-    public function __construct(
-        public array $criteria = [],
-    ) {}
+    public array $criteria;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(SortCriterion $criterion, SortCriterion ...$criteria)
+    {
+        $this->criteria = [$criterion, ...$criteria];
+    }
 
     /**
      * Add a sort criterion.

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -12,6 +12,8 @@ use Exception;
 
 class Mailbox implements MailboxInterface
 {
+    use HasCapabilities;
+
     /**
      * The mailbox configuration.
      */

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -52,6 +52,11 @@ interface MailboxInterface
     public function capabilities(): array;
 
     /**
+     * Determine if the mailbox supports the given capability.
+     */
+    public function hasCapability(string $capability): bool;
+
+    /**
      * Select the given folder.
      */
     public function select(FolderInterface $folder, bool $force = false): void;

--- a/src/Message.php
+++ b/src/Message.php
@@ -187,9 +187,7 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     {
         $mailbox = $this->folder->mailbox();
 
-        $capabilities = $mailbox->capabilities();
-
-        if (! in_array('UIDPLUS', $capabilities)) {
+        if (! $mailbox->hasCapability('UIDPLUS')) {
             throw new ImapCapabilityException(
                 'Unable to copy message. IMAP server does not support UIDPLUS capability'
             );
@@ -209,15 +207,13 @@ class Message implements Arrayable, JsonSerializable, MessageInterface
     {
         $mailbox = $this->folder->mailbox();
 
-        $capabilities = $mailbox->capabilities();
-
         switch (true) {
-            case in_array('MOVE', $capabilities):
+            case $mailbox->hasCapability('MOVE'):
                 $response = $mailbox->connection()->move($folder, $this->uid);
 
                 return MessageResponseParser::getUidFromCopy($response);
 
-            case in_array('UIDPLUS', $capabilities):
+            case $mailbox->hasCapability('UIDPLUS'):
                 $uid = $this->copy($folder);
 
                 $this->delete($expunge);

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -12,6 +12,7 @@ use DirectoryTree\ImapEngine\Connection\Responses\UntaggedResponse;
 use DirectoryTree\ImapEngine\Connection\Tokens\Token;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
+use DirectoryTree\ImapEngine\Enums\SortDirection;
 use DirectoryTree\ImapEngine\Exceptions\ImapCapabilityException;
 use DirectoryTree\ImapEngine\Exceptions\ImapCommandException;
 use DirectoryTree\ImapEngine\MessageData\FetchItem;
@@ -342,8 +343,8 @@ class MessageQuery implements MessageQueryInterface
         // in the correct order, so we should preserve that order.
         if (! $this->sortKey) {
             $messages = match ($this->fetchOrder) {
-                'asc' => $messages->sort(SORT_NUMERIC),
-                'desc' => $messages->sortDesc(SORT_NUMERIC),
+                SortDirection::Ascending => $messages->sort(SORT_NUMERIC),
+                SortDirection::Descending => $messages->sortDesc(SORT_NUMERIC),
             };
         }
 
@@ -404,7 +405,7 @@ class MessageQuery implements MessageQueryInterface
 
         $response = $this->connection()->sort(
             $this->sortKey,
-            $this->sortDirection,
+            $this->sortDirection->value,
             [$this->query->toImap()]
         );
 

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -419,10 +419,9 @@ class MessageQuery implements MessageQueryInterface
             $this->query->all();
         }
 
-        $response = $this->connection()->sort(
-            $sort,
-            [$this->query->toImap()]
-        );
+        $response = $this->connection()->sort($sort, [
+            $this->query->toImap(),
+        ]);
 
         return new Collection(array_map(
             fn (Token $token) => $token->value,

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -34,7 +34,9 @@ class MessageQuery implements MessageQueryInterface
     public function __construct(
         protected FolderInterface $folder,
         protected ImapQueryBuilder $query,
-    ) {}
+    ) {
+        $this->ordering = new UidOrder(SortDirection::Descending);
+    }
 
     /**
      * Count all available messages matching the current search criteria.
@@ -69,7 +71,7 @@ class MessageQuery implements MessageQueryInterface
      */
     public function get(): MessageCollection
     {
-        return $this->process($this->sortCriteria ? $this->sort() : $this->search());
+        return $this->process($this->orderedUids());
     }
 
     /**
@@ -104,8 +106,8 @@ class MessageQuery implements MessageQueryInterface
         $startChunk = max($startChunk, 1);
         $chunkSize = max($chunkSize, 1);
 
-        // Get all search result tokens once.
-        $messages = $this->search();
+        // Get all ordered result tokens once.
+        $messages = $this->orderedUids();
 
         // Calculate how many chunks there are
         $totalChunks = (int) ceil($messages->count() / $chunkSize);
@@ -338,8 +340,8 @@ class MessageQuery implements MessageQueryInterface
      */
     protected function fetch(Collection $messages): array
     {
-        if ($this->uidOrder) {
-            $messages = match ($this->uidOrder) {
+        if ($this->ordering instanceof UidOrder) {
+            $messages = match ($this->ordering->direction) {
                 SortDirection::Ascending => $messages->sort(SORT_NUMERIC),
                 SortDirection::Descending => $messages->sortDesc(SORT_NUMERIC),
             };
@@ -366,6 +368,17 @@ class MessageQuery implements MessageQueryInterface
     }
 
     /**
+     * Get the ordered message UIDs.
+     */
+    protected function orderedUids(): Collection
+    {
+        return match (true) {
+            $this->ordering instanceof UidOrder => $this->search(),
+            $this->ordering instanceof ImapSort => $this->sort($this->ordering),
+        };
+    }
+
+    /**
      * Execute an IMAP search request.
      */
     protected function search(): Collection
@@ -388,7 +401,7 @@ class MessageQuery implements MessageQueryInterface
     /**
      * Execute an IMAP UID SORT request using RFC 5256.
      */
-    protected function sort(): Collection
+    protected function sort(ImapSort $sort): Collection
     {
         if (! in_array('SORT', $this->folder->mailbox()->capabilities())) {
             throw new ImapCapabilityException(
@@ -401,7 +414,7 @@ class MessageQuery implements MessageQueryInterface
         }
 
         $response = $this->connection()->sort(
-            $this->sortCriteria,
+            $sort,
             [$this->query->toImap()]
         );
 

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -69,7 +69,7 @@ class MessageQuery implements MessageQueryInterface
      */
     public function get(): MessageCollection
     {
-        return $this->process($this->sortKey ? $this->sort() : $this->search());
+        return $this->process($this->sortCriteria ? $this->sort() : $this->search());
     }
 
     /**
@@ -338,11 +338,8 @@ class MessageQuery implements MessageQueryInterface
      */
     protected function fetch(Collection $messages): array
     {
-        // Only apply client-side sorting when not using server-side sorting.
-        // When sortKey is set, the IMAP SORT command already returns UIDs
-        // in the correct order, so we should preserve that order.
-        if (! $this->sortKey) {
-            $messages = match ($this->fetchOrder) {
+        if ($this->uidOrder) {
+            $messages = match ($this->uidOrder) {
                 SortDirection::Ascending => $messages->sort(SORT_NUMERIC),
                 SortDirection::Descending => $messages->sortDesc(SORT_NUMERIC),
             };
@@ -404,8 +401,7 @@ class MessageQuery implements MessageQueryInterface
         }
 
         $response = $this->connection()->sort(
-            $this->sortKey,
-            $this->sortDirection->value,
+            $this->sortCriteria,
             [$this->query->toImap()]
         );
 

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -71,7 +71,7 @@ class MessageQuery implements MessageQueryInterface
      */
     public function get(): MessageCollection
     {
-        return $this->process($this->orderedUids());
+        return $this->process($this->uids());
     }
 
     /**
@@ -107,7 +107,7 @@ class MessageQuery implements MessageQueryInterface
         $chunkSize = max($chunkSize, 1);
 
         // Get all ordered result tokens once.
-        $messages = $this->orderedUids();
+        $messages = $this->uids();
 
         // Calculate how many chunks there are
         $totalChunks = (int) ceil($messages->count() / $chunkSize);
@@ -376,7 +376,7 @@ class MessageQuery implements MessageQueryInterface
     /**
      * Get the ordered message UIDs.
      */
-    protected function orderedUids(): Collection
+    protected function uids(): Collection
     {
         return match (true) {
             $this->ordering instanceof UidOrder => $this->search(),

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -409,11 +409,7 @@ class MessageQuery implements MessageQueryInterface
      */
     protected function sort(ImapSort $sort): Collection
     {
-        $supportsSort = collect($this->folder->mailbox()->capabilities())->contains(
-            fn (string $capability) => str_starts_with(strtoupper($capability), 'SORT')
-        );
-
-        if (! $supportsSort) {
+        if (! $this->folder->mailbox()->hasCapability('SORT')) {
             throw new ImapCapabilityException(
                 'Unable to sort messages. IMAP server does not support SORT capability.'
             );

--- a/src/MessageQuery.php
+++ b/src/MessageQuery.php
@@ -360,11 +360,17 @@ class MessageQuery implements MessageQueryInterface
             ])->all();
         }
 
-        return $this->connection()->fetch($fetch, $uids->all())->mapWithKeys(function (UntaggedResponse $response) {
+        $fetched = $this->connection()->fetch($fetch, $uids->all())->mapWithKeys(function (UntaggedResponse $response) {
             $data = FetchedMessageData::fromResponse($response);
 
             return [$data->uid() => $data];
-        })->all();
+        });
+
+        return $uids
+            ->map(fn (string|int $uid) => $fetched->get($uid))
+            ->filter()
+            ->mapWithKeys(fn (FetchedMessageData $data) => [$data->uid() => $data])
+            ->all();
     }
 
     /**
@@ -403,7 +409,11 @@ class MessageQuery implements MessageQueryInterface
      */
     protected function sort(ImapSort $sort): Collection
     {
-        if (! in_array('SORT', $this->folder->mailbox()->capabilities())) {
+        $supportsSort = collect($this->folder->mailbox()->capabilities())->contains(
+            fn (string $capability) => str_starts_with(strtoupper($capability), 'SORT')
+        );
+
+        if (! $supportsSort) {
             throw new ImapCapabilityException(
                 'Unable to sort messages. IMAP server does not support SORT capability.'
             );

--- a/src/MessageQueryInterface.php
+++ b/src/MessageQueryInterface.php
@@ -58,27 +58,21 @@ interface MessageQueryInterface
     public function only(FetchItem ...$items): static;
 
     /**
-     * Fetch messages in ascending UID order.
+     * Order messages locally by UID, replacing any server-side sort criteria.
      */
-    public function oldest(): static;
+    public function orderByUid(
+        SortDirection|string $direction = SortDirection::Ascending,
+    ): static;
 
     /**
-     * Fetch messages in descending UID order.
-     */
-    public function newest(): static;
-
-    /**
-     * Sort messages by a field using server-side sorting (RFC 5256).
+     * Add a server-side sort criterion using RFC 5256.
+     *
+     * Subsequent calls are used as tie-breakers in the order they are added.
      */
     public function sortBy(
         ImapSortKey|string $key,
         SortDirection|string $direction = SortDirection::Ascending,
     ): static;
-
-    /**
-     * Sort messages by a field in descending order using server-side sorting.
-     */
-    public function sortByDesc(ImapSortKey|string $key): static;
 
     /**
      * Count all available messages matching the current search criteria.

--- a/src/MessageQueryInterface.php
+++ b/src/MessageQueryInterface.php
@@ -8,6 +8,7 @@ use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
 use DirectoryTree\ImapEngine\Enums\ImapSortKey;
+use DirectoryTree\ImapEngine\Enums\SortDirection;
 use DirectoryTree\ImapEngine\MessageData\FetchItem;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
 
@@ -57,64 +58,27 @@ interface MessageQueryInterface
     public function only(FetchItem ...$items): static;
 
     /**
-     * Set the fetch order.
+     * Fetch messages in ascending UID order.
      */
-    public function setFetchOrder(string $fetchOrder): MessageQueryInterface;
+    public function oldest(): static;
 
     /**
-     * Get the fetch order.
+     * Fetch messages in descending UID order.
      */
-    public function getFetchOrder(): string;
-
-    /**
-     * Set the fetch order to 'ascending'.
-     */
-    public function setFetchOrderAsc(): MessageQueryInterface;
-
-    /**
-     * Set the fetch order to 'descending'.
-     */
-    public function setFetchOrderDesc(): MessageQueryInterface;
-
-    /**
-     * Set the fetch order to show oldest messages first (ascending).
-     */
-    public function oldest(): MessageQueryInterface;
-
-    /**
-     * Set the fetch order to show newest messages first (descending).
-     */
-    public function newest(): MessageQueryInterface;
-
-    /**
-     * Set the sort key for server-side sorting (RFC 5256).
-     */
-    public function setSortKey(ImapSortKey|string|null $key): MessageQueryInterface;
-
-    /**
-     * Get the sort key for server-side sorting.
-     */
-    public function getSortKey(): ?ImapSortKey;
-
-    /**
-     * Set the sort direction for server-side sorting.
-     */
-    public function setSortDirection(string $direction): MessageQueryInterface;
-
-    /**
-     * Get the sort direction for server-side sorting.
-     */
-    public function getSortDirection(): string;
+    public function newest(): static;
 
     /**
      * Sort messages by a field using server-side sorting (RFC 5256).
      */
-    public function sortBy(ImapSortKey|string $key, string $direction = 'asc'): MessageQueryInterface;
+    public function sortBy(
+        ImapSortKey|string $key,
+        SortDirection|string $direction = SortDirection::Ascending,
+    ): static;
 
     /**
      * Sort messages by a field in descending order using server-side sorting.
      */
-    public function sortByDesc(ImapSortKey|string $key): MessageQueryInterface;
+    public function sortByDesc(ImapSortKey|string $key): static;
 
     /**
      * Count all available messages matching the current search criteria.

--- a/src/QueriesMessages.php
+++ b/src/QueriesMessages.php
@@ -173,11 +173,13 @@ trait QueriesMessages
             ? SortDirection::from(strtolower($direction))
             : $direction;
 
-        if (! $this->ordering instanceof ImapSort) {
-            $this->ordering = new ImapSort;
-        }
+        $criterion = new SortCriterion($key, $direction);
 
-        $this->ordering->add(new SortCriterion($key, $direction));
+        if ($this->ordering instanceof ImapSort) {
+            $this->ordering->add($criterion);
+        } else {
+            $this->ordering = new ImapSort($criterion);
+        }
 
         return $this;
     }

--- a/src/QueriesMessages.php
+++ b/src/QueriesMessages.php
@@ -36,9 +36,9 @@ trait QueriesMessages
     protected array $fetchItems = [];
 
     /**
-     * The fetch order.
+     * The UID order.
      */
-    protected SortDirection $fetchOrder = SortDirection::Descending;
+    protected ?SortDirection $uidOrder = SortDirection::Descending;
 
     /**
      * The methods that should be returned from query builder.
@@ -46,14 +46,11 @@ trait QueriesMessages
     protected array $passthru = ['toimap', 'isempty'];
 
     /**
-     * The sort key for server-side sorting (RFC 5256).
+     * The criteria for server-side sorting (RFC 5256).
+     *
+     * @var array<int, SortCriterion>
      */
-    protected ?ImapSortKey $sortKey = null;
-
-    /**
-     * The sort direction for server-side sorting.
-     */
-    protected SortDirection $sortDirection = SortDirection::Ascending;
+    protected array $sortCriteria = [];
 
     /**
      * Handle dynamic method calls into the query builder.
@@ -156,19 +153,14 @@ trait QueriesMessages
     /**
      * {@inheritDoc}
      */
-    public function oldest(): static
-    {
-        $this->fetchOrder = SortDirection::Ascending;
+    public function orderByUid(
+        SortDirection|string $direction = SortDirection::Ascending,
+    ): static {
+        $this->uidOrder = is_string($direction)
+            ? SortDirection::from(strtolower($direction))
+            : $direction;
 
-        return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function newest(): static
-    {
-        $this->fetchOrder = SortDirection::Descending;
+        $this->sortCriteria = [];
 
         return $this;
     }
@@ -180,22 +172,17 @@ trait QueriesMessages
         ImapSortKey|string $key,
         SortDirection|string $direction = SortDirection::Ascending,
     ): static {
-        $this->sortKey = is_string($key)
+        $key = is_string($key)
             ? ImapSortKey::from(strtoupper($key))
             : $key;
 
-        $this->sortDirection = is_string($direction)
+        $direction = is_string($direction)
             ? SortDirection::from(strtolower($direction))
             : $direction;
 
-        return $this;
-    }
+        $this->uidOrder = null;
+        $this->sortCriteria[] = new SortCriterion($key, $direction);
 
-    /**
-     * {@inheritDoc}
-     */
-    public function sortByDesc(ImapSortKey|string $key): static
-    {
-        return $this->sortBy($key, SortDirection::Descending);
+        return $this;
     }
 }

--- a/src/QueriesMessages.php
+++ b/src/QueriesMessages.php
@@ -4,6 +4,7 @@ namespace DirectoryTree\ImapEngine;
 
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapSortKey;
+use DirectoryTree\ImapEngine\Enums\SortDirection;
 use DirectoryTree\ImapEngine\MessageData\FetchItem;
 use DirectoryTree\ImapEngine\Support\ForwardsCalls;
 use Illuminate\Support\Traits\Conditionable;
@@ -36,10 +37,8 @@ trait QueriesMessages
 
     /**
      * The fetch order.
-     *
-     * @var 'asc'|'desc'
      */
-    protected string $fetchOrder = 'desc';
+    protected SortDirection $fetchOrder = SortDirection::Descending;
 
     /**
      * The methods that should be returned from query builder.
@@ -53,10 +52,8 @@ trait QueriesMessages
 
     /**
      * The sort direction for server-side sorting.
-     *
-     * @var 'asc'|'desc'
      */
-    protected string $sortDirection = 'asc';
+    protected SortDirection $sortDirection = SortDirection::Ascending;
 
     /**
      * Handle dynamic method calls into the query builder.
@@ -156,14 +153,12 @@ trait QueriesMessages
         return $this->with(...$items);
     }
 
-    /** {@inheritDoc} */
-    public function setFetchOrder(string $fetchOrder): MessageQueryInterface
+    /**
+     * {@inheritDoc}
+     */
+    public function oldest(): static
     {
-        $fetchOrder = strtolower($fetchOrder);
-
-        if (in_array($fetchOrder, ['asc', 'desc'])) {
-            $this->fetchOrder = $fetchOrder;
-        }
+        $this->fetchOrder = SortDirection::Ascending;
 
         return $this;
     }
@@ -171,53 +166,9 @@ trait QueriesMessages
     /**
      * {@inheritDoc}
      */
-    public function getFetchOrder(): string
+    public function newest(): static
     {
-        return $this->fetchOrder;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setFetchOrderAsc(): MessageQueryInterface
-    {
-        return $this->setFetchOrder('asc');
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setFetchOrderDesc(): MessageQueryInterface
-    {
-        return $this->setFetchOrder('desc');
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function oldest(): MessageQueryInterface
-    {
-        return $this->setFetchOrder('asc');
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function newest(): MessageQueryInterface
-    {
-        return $this->setFetchOrder('desc');
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setSortKey(ImapSortKey|string|null $key): MessageQueryInterface
-    {
-        if (is_string($key)) {
-            $key = ImapSortKey::from(strtoupper($key));
-        }
-
-        $this->sortKey = $key;
+        $this->fetchOrder = SortDirection::Descending;
 
         return $this;
     }
@@ -225,21 +176,17 @@ trait QueriesMessages
     /**
      * {@inheritDoc}
      */
-    public function getSortKey(): ?ImapSortKey
-    {
-        return $this->sortKey;
-    }
+    public function sortBy(
+        ImapSortKey|string $key,
+        SortDirection|string $direction = SortDirection::Ascending,
+    ): static {
+        $this->sortKey = is_string($key)
+            ? ImapSortKey::from(strtoupper($key))
+            : $key;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function setSortDirection(string $direction): MessageQueryInterface
-    {
-        $direction = strtolower($direction);
-
-        if (in_array($direction, ['asc', 'desc'])) {
-            $this->sortDirection = $direction;
-        }
+        $this->sortDirection = is_string($direction)
+            ? SortDirection::from(strtolower($direction))
+            : $direction;
 
         return $this;
     }
@@ -247,24 +194,8 @@ trait QueriesMessages
     /**
      * {@inheritDoc}
      */
-    public function getSortDirection(): string
+    public function sortByDesc(ImapSortKey|string $key): static
     {
-        return $this->sortDirection;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function sortBy(ImapSortKey|string $key, string $direction = 'asc'): MessageQueryInterface
-    {
-        return $this->setSortKey($key)->setSortDirection($direction);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function sortByDesc(ImapSortKey|string $key): MessageQueryInterface
-    {
-        return $this->sortBy($key, 'desc');
+        return $this->sortBy($key, SortDirection::Descending);
     }
 }

--- a/src/QueriesMessages.php
+++ b/src/QueriesMessages.php
@@ -7,6 +7,7 @@ use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\Enums\SortDirection;
 use DirectoryTree\ImapEngine\MessageData\FetchItem;
 use DirectoryTree\ImapEngine\Support\ForwardsCalls;
+use DirectoryTree\ImapEngine\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 
 trait QueriesMessages
@@ -150,9 +151,7 @@ trait QueriesMessages
         SortDirection|string $direction = SortDirection::Ascending,
     ): static {
         $this->ordering = new UidOrder(
-            is_string($direction)
-                ? SortDirection::from(strtolower($direction))
-                : $direction,
+            SortDirection::from(strtolower(Str::enum($direction))),
         );
 
         return $this;
@@ -165,13 +164,9 @@ trait QueriesMessages
         ImapSortKey|string $key,
         SortDirection|string $direction = SortDirection::Ascending,
     ): static {
-        $key = is_string($key)
-            ? ImapSortKey::from(strtoupper($key))
-            : $key;
+        $key = ImapSortKey::from(strtoupper(Str::enum($key)));
 
-        $direction = is_string($direction)
-            ? SortDirection::from(strtolower($direction))
-            : $direction;
+        $direction = SortDirection::from(strtolower(Str::enum($direction)));
 
         $criterion = new SortCriterion($key, $direction);
 

--- a/src/QueriesMessages.php
+++ b/src/QueriesMessages.php
@@ -36,21 +36,14 @@ trait QueriesMessages
     protected array $fetchItems = [];
 
     /**
-     * The UID order.
+     * The message ordering strategy.
      */
-    protected ?SortDirection $uidOrder = SortDirection::Descending;
+    protected UidOrder|ImapSort $ordering;
 
     /**
      * The methods that should be returned from query builder.
      */
     protected array $passthru = ['toimap', 'isempty'];
-
-    /**
-     * The criteria for server-side sorting (RFC 5256).
-     *
-     * @var array<int, SortCriterion>
-     */
-    protected array $sortCriteria = [];
 
     /**
      * Handle dynamic method calls into the query builder.
@@ -156,11 +149,11 @@ trait QueriesMessages
     public function orderByUid(
         SortDirection|string $direction = SortDirection::Ascending,
     ): static {
-        $this->uidOrder = is_string($direction)
-            ? SortDirection::from(strtolower($direction))
-            : $direction;
-
-        $this->sortCriteria = [];
+        $this->ordering = new UidOrder(
+            is_string($direction)
+                ? SortDirection::from(strtolower($direction))
+                : $direction,
+        );
 
         return $this;
     }
@@ -180,8 +173,11 @@ trait QueriesMessages
             ? SortDirection::from(strtolower($direction))
             : $direction;
 
-        $this->uidOrder = null;
-        $this->sortCriteria[] = new SortCriterion($key, $direction);
+        if (! $this->ordering instanceof ImapSort) {
+            $this->ordering = new ImapSort;
+        }
+
+        $this->ordering->add(new SortCriterion($key, $direction));
 
         return $this;
     }

--- a/src/SortCriterion.php
+++ b/src/SortCriterion.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DirectoryTree\ImapEngine;
+
+use DirectoryTree\ImapEngine\Enums\ImapSortKey;
+use DirectoryTree\ImapEngine\Enums\SortDirection;
+
+class SortCriterion
+{
+    public function __construct(
+        public ImapSortKey $key,
+        public SortDirection $direction = SortDirection::Ascending,
+    ) {}
+
+    /**
+     * Get the IMAP SORT criterion.
+     */
+    public function toImap(): string
+    {
+        return match ($this->direction) {
+            SortDirection::Ascending => $this->key->value,
+            SortDirection::Descending => "REVERSE {$this->key->value}",
+        };
+    }
+}

--- a/src/SortCriterion.php
+++ b/src/SortCriterion.php
@@ -7,6 +7,9 @@ use DirectoryTree\ImapEngine\Enums\SortDirection;
 
 class SortCriterion
 {
+    /**
+     * Constructor.
+     */
     public function __construct(
         public ImapSortKey $key,
         public SortDirection $direction = SortDirection::Ascending,

--- a/src/Testing/FakeMailbox.php
+++ b/src/Testing/FakeMailbox.php
@@ -6,10 +6,13 @@ use DirectoryTree\ImapEngine\Connection\ConnectionInterface;
 use DirectoryTree\ImapEngine\Exceptions\Exception;
 use DirectoryTree\ImapEngine\FolderInterface;
 use DirectoryTree\ImapEngine\FolderRepositoryInterface;
+use DirectoryTree\ImapEngine\HasCapabilities;
 use DirectoryTree\ImapEngine\MailboxInterface;
 
 class FakeMailbox implements MailboxInterface
 {
+    use HasCapabilities;
+
     /**
      * The currently selected folder.
      */

--- a/src/Testing/FakeMessageQuery.php
+++ b/src/Testing/FakeMessageQuery.php
@@ -8,6 +8,7 @@ use DirectoryTree\ImapEngine\AppendResult;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
+use DirectoryTree\ImapEngine\Enums\ImapSortKey;
 use DirectoryTree\ImapEngine\Enums\SortDirection;
 use DirectoryTree\ImapEngine\MessageInterface;
 use DirectoryTree\ImapEngine\MessageQueryInterface;
@@ -34,9 +35,9 @@ class FakeMessageQuery implements MessageQueryInterface
      */
     public function get(): MessageCollection
     {
-        return new MessageCollection(
+        return $this->applyOrdering(new MessageCollection(
             $this->folder->getMessages()
-        );
+        ));
     }
 
     /**
@@ -70,17 +71,53 @@ class FakeMessageQuery implements MessageQueryInterface
      */
     public function append(string $message, mixed $flags = null, ?DateTimeInterface $date = null): AppendResult
     {
-        $uid = 1;
-
-        if ($lastMessage = $this->get()->last()) {
-            $uid = $lastMessage->uid() + 1;
-        }
+        $uid = (int) collect($this->folder->getMessages())->max(
+            fn (FakeMessage $message) => $message->uid()
+        ) + 1;
 
         $this->folder->addMessage(
             new FakeMessage($uid, $flags === null ? [] : $flags, $message)
         );
 
         return new AppendResult(uid: $uid);
+    }
+
+    /**
+     * Apply the selected ordering strategy.
+     */
+    protected function applyOrdering(MessageCollection $messages): MessageCollection
+    {
+        if ($this->ordering instanceof UidOrder) {
+            return $messages->sortBy(
+                fn (MessageInterface $message) => $message->uid(),
+                descending: $this->ordering->direction === SortDirection::Descending,
+            )->values();
+        }
+
+        foreach (array_reverse($this->ordering->criteria) as $criterion) {
+            $messages = $messages->sortBy(
+                fn (MessageInterface $message) => $this->sortValue($message, $criterion->key),
+                descending: $criterion->direction === SortDirection::Descending,
+            );
+        }
+
+        return $messages->values();
+    }
+
+    /**
+     * Get a message's value for the given sort key.
+     */
+    protected function sortValue(MessageInterface $message, ImapSortKey $key): mixed
+    {
+        return match ($key) {
+            ImapSortKey::Cc => head($message->cc())?->email() ?? '',
+            ImapSortKey::To => head($message->to())?->email() ?? '',
+            ImapSortKey::Date => $message->date()?->getTimestamp() ?? 0,
+            ImapSortKey::From => $message->from()?->email() ?? '',
+            ImapSortKey::Size => $message->size(),
+            ImapSortKey::Arrival => $message->uid(),
+            ImapSortKey::Subject => $message->subject() ?? '',
+        };
     }
 
     /**

--- a/src/Testing/FakeMessageQuery.php
+++ b/src/Testing/FakeMessageQuery.php
@@ -8,10 +8,12 @@ use DirectoryTree\ImapEngine\AppendResult;
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
 use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Enums\ImapFetchIdentifier;
+use DirectoryTree\ImapEngine\Enums\SortDirection;
 use DirectoryTree\ImapEngine\MessageInterface;
 use DirectoryTree\ImapEngine\MessageQueryInterface;
 use DirectoryTree\ImapEngine\Pagination\LengthAwarePaginator;
 use DirectoryTree\ImapEngine\QueriesMessages;
+use DirectoryTree\ImapEngine\UidOrder;
 
 class FakeMessageQuery implements MessageQueryInterface
 {
@@ -23,7 +25,9 @@ class FakeMessageQuery implements MessageQueryInterface
     public function __construct(
         protected FakeFolder $folder,
         protected ImapQueryBuilder $query = new ImapQueryBuilder
-    ) {}
+    ) {
+        $this->ordering = new UidOrder(SortDirection::Descending);
+    }
 
     /**
      * {@inheritDoc}

--- a/src/UidOrder.php
+++ b/src/UidOrder.php
@@ -6,6 +6,9 @@ use DirectoryTree\ImapEngine\Enums\SortDirection;
 
 class UidOrder
 {
+    /**
+     * Constructor.
+     */
     public function __construct(
         public SortDirection $direction,
     ) {}

--- a/src/UidOrder.php
+++ b/src/UidOrder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DirectoryTree\ImapEngine;
+
+use DirectoryTree\ImapEngine\Enums\SortDirection;
+
+class UidOrder
+{
+    public function __construct(
+        public SortDirection $direction,
+    ) {}
+}

--- a/tests/Unit/MailboxTest.php
+++ b/tests/Unit/MailboxTest.php
@@ -152,4 +152,10 @@ test('capabilities', function () {
         'STARTTLS',
         'AUTH=PLAIN',
     ]);
+
+    expect($mailbox->hasCapability('imap4rev1'))->toBeTrue();
+    expect($mailbox->hasCapability('AUTH'))->toBeTrue();
+    expect($mailbox->hasCapability('AUTH=PLAIN'))->toBeTrue();
+    expect($mailbox->hasCapability('AUTH=LOGIN'))->toBeFalse();
+    expect($mailbox->hasCapability('START'))->toBeFalse();
 });

--- a/tests/Unit/MessageQueryTest.php
+++ b/tests/Unit/MessageQueryTest.php
@@ -5,6 +5,7 @@ use DirectoryTree\ImapEngine\Connection\ImapQueryBuilder;
 use DirectoryTree\ImapEngine\Connection\Streams\FakeStream;
 use DirectoryTree\ImapEngine\Enums\ImapFlag;
 use DirectoryTree\ImapEngine\Enums\ImapSortKey;
+use DirectoryTree\ImapEngine\Enums\SortDirection;
 use DirectoryTree\ImapEngine\Exceptions\ImapCapabilityException;
 use DirectoryTree\ImapEngine\Folder;
 use DirectoryTree\ImapEngine\Mailbox;
@@ -152,20 +153,46 @@ test('destroy with expunge only expunges the given messages', function () {
     $stream->assertWritten('TAG3 UID EXPUNGE 1:3');
 });
 
-test('oldest sets fetch order to asc', function () {
-    $query = query();
+test('oldest returns messages in ascending UID order', function () {
+    $stream = new FakeStream;
+    $stream->open();
 
-    $query->oldest();
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* SEARCH 3 1 2',
+        'TAG2 OK UID SEARCH completed',
+    ]);
 
-    expect($query->getFetchOrder())->toBe('asc');
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    $uids = query($mailbox)->oldest()->get()->map(
+        fn ($message) => $message->uid()
+    )->all();
+
+    expect($uids)->toBe([1, 2, 3]);
 });
 
-test('newest sets fetch order to desc', function () {
-    $query = query();
+test('newest returns messages in descending UID order', function () {
+    $stream = new FakeStream;
+    $stream->open();
 
-    $query->newest();
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* SEARCH 2 3 1',
+        'TAG2 OK UID SEARCH completed',
+    ]);
 
-    expect($query->getFetchOrder())->toBe('desc');
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    $uids = query($mailbox)->newest()->get()->map(
+        fn ($message) => $message->uid()
+    )->all();
+
+    expect($uids)->toBe([3, 2, 1]);
 });
 
 test('oldest and newest return query instance for chaining', function () {
@@ -585,6 +612,10 @@ test('sortBy fails with incorrect string key', function () {
     query()->sortBy('invalid');
 })->throws(ValueError::class);
 
+test('sortBy fails with incorrect string direction', function () {
+    query()->sortBy('date', 'invalid');
+})->throws(ValueError::class);
+
 test('sortBy sends correct sort command with ascending order', function () {
     $stream = new FakeStream;
     $stream->open();
@@ -622,7 +653,7 @@ test('sortBy sends correct sort command with descending order', function () {
     $mailbox = Mailbox::make();
     $mailbox->connect(new ImapConnection($stream));
 
-    query($mailbox)->sortBy('date', 'desc')->get();
+    query($mailbox)->sortByDesc('date')->get();
 
     $stream->assertWritten('TAG3 UID SORT (REVERSE DATE) UTF-8 ALL');
 });
@@ -664,7 +695,7 @@ test('sortBy combined with search criteria', function () {
     $mailbox = Mailbox::make();
     $mailbox->connect(new ImapConnection($stream));
 
-    query($mailbox)->unseen()->sortBy('arrival', 'desc')->get();
+    query($mailbox)->unseen()->sortBy('arrival', SortDirection::Descending)->get();
 
     $stream->assertWritten('TAG3 UID SORT (REVERSE ARRIVAL) UTF-8 UNSEEN');
 });

--- a/tests/Unit/MessageQueryTest.php
+++ b/tests/Unit/MessageQueryTest.php
@@ -630,6 +630,10 @@ test('sortBy sends correct sort command with ascending order', function () {
         'TAG2 OK CAPABILITY completed',
         '* SORT 3 1 2',
         'TAG3 OK SORT completed',
+        '* 1 FETCH (UID 1 FLAGS ())',
+        '* 2 FETCH (UID 2 FLAGS ())',
+        '* 3 FETCH (UID 3 FLAGS ())',
+        'TAG4 OK UID FETCH completed',
     ]);
 
     $mailbox = Mailbox::make();
@@ -638,6 +642,7 @@ test('sortBy sends correct sort command with ascending order', function () {
     $uids = query($mailbox)
         ->orderByUid(SortDirection::Descending)
         ->sortBy('date')
+        ->with(MessageData::flags())
         ->get()
         ->map(fn ($message) => $message->uid())
         ->all();
@@ -645,6 +650,27 @@ test('sortBy sends correct sort command with ascending order', function () {
     $stream->assertWritten('TAG3 UID SORT (DATE) UTF-8 ALL');
 
     expect($uids)->toBe([3, 1, 2]);
+});
+
+test('sortBy recognizes extended SORT capabilities', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* CAPABILITY IMAP4rev1 SORT=DISPLAY',
+        'TAG2 OK CAPABILITY completed',
+        '* SORT 1',
+        'TAG3 OK SORT completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    query($mailbox)->sortBy('date')->get();
+
+    $stream->assertWritten('TAG3 UID SORT (DATE) UTF-8 ALL');
 });
 
 test('sortBy sends correct sort command with descending order', function () {

--- a/tests/Unit/MessageQueryTest.php
+++ b/tests/Unit/MessageQueryTest.php
@@ -153,7 +153,7 @@ test('destroy with expunge only expunges the given messages', function () {
     $stream->assertWritten('TAG3 UID EXPUNGE 1:3');
 });
 
-test('oldest returns messages in ascending UID order', function () {
+test('orderByUid returns messages in ascending UID order', function () {
     $stream = new FakeStream;
     $stream->open();
 
@@ -167,14 +167,14 @@ test('oldest returns messages in ascending UID order', function () {
     $mailbox = Mailbox::make();
     $mailbox->connect(new ImapConnection($stream));
 
-    $uids = query($mailbox)->oldest()->get()->map(
+    $uids = query($mailbox)->orderByUid()->get()->map(
         fn ($message) => $message->uid()
     )->all();
 
     expect($uids)->toBe([1, 2, 3]);
 });
 
-test('newest returns messages in descending UID order', function () {
+test('orderByUid returns messages in descending UID order', function () {
     $stream = new FakeStream;
     $stream->open();
 
@@ -188,19 +188,22 @@ test('newest returns messages in descending UID order', function () {
     $mailbox = Mailbox::make();
     $mailbox->connect(new ImapConnection($stream));
 
-    $uids = query($mailbox)->newest()->get()->map(
+    $uids = query($mailbox)->orderByUid(SortDirection::Descending)->get()->map(
         fn ($message) => $message->uid()
     )->all();
 
     expect($uids)->toBe([3, 2, 1]);
 });
 
-test('oldest and newest return query instance for chaining', function () {
+test('orderByUid returns query instance for chaining', function () {
     $query = query();
 
-    expect($query->oldest())->toBe($query);
-    expect($query->newest())->toBe($query);
+    expect($query->orderByUid())->toBe($query);
 });
+
+test('orderByUid fails with incorrect string direction', function () {
+    query()->orderByUid('invalid');
+})->throws(ValueError::class);
 
 test('each breaks when callback returns false', function () {
     $stream = new FakeStream;
@@ -632,9 +635,16 @@ test('sortBy sends correct sort command with ascending order', function () {
     $mailbox = Mailbox::make();
     $mailbox->connect(new ImapConnection($stream));
 
-    query($mailbox)->sortBy('date')->get();
+    $uids = query($mailbox)
+        ->orderByUid(SortDirection::Descending)
+        ->sortBy('date')
+        ->get()
+        ->map(fn ($message) => $message->uid())
+        ->all();
 
     $stream->assertWritten('TAG3 UID SORT (DATE) UTF-8 ALL');
+
+    expect($uids)->toBe([3, 1, 2]);
 });
 
 test('sortBy sends correct sort command with descending order', function () {
@@ -653,9 +663,57 @@ test('sortBy sends correct sort command with descending order', function () {
     $mailbox = Mailbox::make();
     $mailbox->connect(new ImapConnection($stream));
 
-    query($mailbox)->sortByDesc('date')->get();
+    query($mailbox)->sortBy('date', SortDirection::Descending)->get();
 
     $stream->assertWritten('TAG3 UID SORT (REVERSE DATE) UTF-8 ALL');
+});
+
+test('sortBy sends multiple sort criteria in priority order', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* CAPABILITY IMAP4rev1 SORT',
+        'TAG2 OK CAPABILITY completed',
+        '* SORT 2 1 3',
+        'TAG3 OK SORT completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    query($mailbox)
+        ->sortBy('subject')
+        ->sortBy('date', SortDirection::Descending)
+        ->get();
+
+    $stream->assertWritten('TAG3 UID SORT (SUBJECT REVERSE DATE) UTF-8 ALL');
+});
+
+test('orderByUid replaces server sorting', function () {
+    $stream = new FakeStream;
+    $stream->open();
+
+    $stream->feed([
+        '* OK Welcome to IMAP',
+        'TAG1 OK Logged in',
+        '* SEARCH 3 1 2',
+        'TAG2 OK UID SEARCH completed',
+    ]);
+
+    $mailbox = Mailbox::make();
+    $mailbox->connect(new ImapConnection($stream));
+
+    $uids = query($mailbox)
+        ->sortBy('date')
+        ->orderByUid()
+        ->get()
+        ->map(fn ($message) => $message->uid())
+        ->all();
+
+    expect($uids)->toBe([1, 2, 3]);
 });
 
 test('sortBy works with ImapSortKey enum', function () {

--- a/tests/Unit/Testing/FakeMailboxTest.php
+++ b/tests/Unit/Testing/FakeMailboxTest.php
@@ -15,6 +15,8 @@ test('it can be created with basic properties', function () {
     expect($mailbox->config('host'))->toBe('imap.example.com');
     expect($mailbox->config('username'))->toBe('user1');
     expect($mailbox->capabilities())->toBe(['IMAP4rev1', 'STARTTLS']);
+    expect($mailbox->hasCapability('imap4rev1'))->toBeTrue();
+    expect($mailbox->hasCapability('START'))->toBeFalse();
 });
 
 test('it returns config values correctly', function () {

--- a/tests/Unit/Testing/FakeMessageQueryTest.php
+++ b/tests/Unit/Testing/FakeMessageQueryTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use DirectoryTree\ImapEngine\Collections\MessageCollection;
+use DirectoryTree\ImapEngine\Enums\ImapSortKey;
+use DirectoryTree\ImapEngine\Enums\SortDirection;
 use DirectoryTree\ImapEngine\Testing\FakeFolder;
 use DirectoryTree\ImapEngine\Testing\FakeMessage;
 use DirectoryTree\ImapEngine\Testing\FakeMessageQuery;
@@ -30,6 +32,48 @@ test('it returns message collection', function () {
     expect($collection)->toHaveCount(2);
 });
 
+test('it orders messages by uid', function () {
+    $folder = new FakeFolder('INBOX', messages: [
+        new FakeMessage(2),
+        new FakeMessage(1),
+        new FakeMessage(3),
+    ]);
+
+    $query = new FakeMessageQuery($folder);
+
+    $ascending = $query
+        ->orderByUid()
+        ->get()
+        ->map(fn (FakeMessage $message) => $message->uid())
+        ->all();
+
+    $descending = $query
+        ->orderByUid(SortDirection::Descending)
+        ->get()
+        ->map(fn (FakeMessage $message) => $message->uid())
+        ->all();
+
+    expect($ascending)->toBe([1, 2, 3])
+        ->and($descending)->toBe([3, 2, 1]);
+});
+
+test('it applies server sort criteria', function () {
+    $folder = new FakeFolder('INBOX', messages: [
+        new FakeMessage(1, contents: "Subject: Zebra\r\n\r\n"),
+        new FakeMessage(2, contents: "Subject: Apple\r\n\r\n"),
+    ]);
+
+    $query = new FakeMessageQuery($folder);
+
+    $uids = $query
+        ->sortBy(ImapSortKey::Subject)
+        ->get()
+        ->map(fn (FakeMessage $message) => $message->uid())
+        ->all();
+
+    expect($uids)->toBe([2, 1]);
+});
+
 test('it counts messages correctly', function () {
     $folder = new FakeFolder('INBOX', messages: [
         new FakeMessage(1),
@@ -53,7 +97,7 @@ test('it returns first message', function () {
     $first = $query->first();
 
     expect($first)->toBeInstanceOf(FakeMessage::class);
-    expect($first->uid())->toBe(1);
+    expect($first->uid())->toBe(2);
 });
 
 test('it returns null when no messages exist for first()', function () {
@@ -195,8 +239,8 @@ test('each breaks when callback returns false', function () {
         }
     }, 2); // Use chunk size of 2
 
-    // Should process messages 1, 2, and 3, then break
-    expect($processedUids)->toBe([1, 2, 3]);
+    // Should process messages 5, 4, and 3, then break
+    expect($processedUids)->toBe([5, 4, 3]);
 });
 
 test('chunk breaks when callback returns false', function () {
@@ -240,7 +284,7 @@ test('each processes all messages when callback never returns false', function (
     });
 
     // Should process all messages
-    expect($processedUids)->toBe([1, 2, 3]);
+    expect($processedUids)->toBe([3, 2, 1]);
 });
 
 test('chunk processes all chunks when callback never returns false', function () {


### PR DESCRIPTION
Message queries currently blur together local UID ordering and RFC 5256 server-side sorting. They also expose oldest() and newest(), even though UID order does not reliably represent message chronology.

This replaces that API with two explicit operations: orderByUid() for capability-free local UID ordering, and sortBy() for server-side sorting. The query stores one UidOrder or ImapSort strategy, making the two modes mutually exclusive without maintaining or resetting parallel properties.

Repeated sortBy() calls add RFC 5256 criteria in priority order, allowing later criteria to act as tie-breakers. Hydrated FETCH responses are rebuilt in the original SORT order, extended SORT capabilities are recognized, and the testing fake applies the same ordering strategies. Server-side sorting continues to fail clearly when the mailbox does not advertise a SORT capability.